### PR TITLE
fix: release workflow - 跳过 beforeBuildCommand 解决 CI 构建失败

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,26 +96,15 @@ jobs:
           name: frontend-dist
           path: apps/desktop/dist
 
-      - name: Build Tauri Rust
-        working-directory: ./apps/desktop/src-tauri
-        shell: bash
-        env:
-          TAURI_BUILD_NON_INCREMENTAL: 'true'
-        run: |
-          # Build Rust binary only, skip frontend build
-          cargo build --release
-
-      - name: Bundle MSI
+      - name: Build Tauri
         working-directory: ./apps/desktop/src-tauri
         shell: pwsh
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: "dummy"
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
         run: |
-          $env:TAURI_SIGNING_PRIVATE_KEY="dummy"
-          $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD=""
-          # Run just the bundler without full build
-          $bundleDir = "target/release/bundle/msi"
-          New-Item -ItemType Directory -Path $bundleDir -Force | Out-Null
-          # Use tauri bundle directly
-          cargo tauri build --bundles msi --no-dev
+          # Override beforeBuildCommand to empty since web is pre-built
+          cargo tauri build --bundles msi --no-dev --ci --config "{\"build\":{\"beforeBuildCommand\":\"\"}}"
 
       - name: Find MSI
         id: msi
@@ -175,19 +164,15 @@ jobs:
           name: frontend-dist
           path: apps/desktop/dist
 
-      - name: Build Tauri Rust
+      - name: Build Tauri
         working-directory: ./apps/desktop/src-tauri
         shell: bash
         env:
-          TAURI_BUILD_NON_INCREMENTAL: 'true'
+          TAURI_SIGNING_PRIVATE_KEY: "dummy"
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
         run: |
-          cargo build --release --target ${{ matrix.arch == 'arm64' && 'aarch64-apple-darwin' || 'x86_64-apple-darwin' }}
-
-      - name: Bundle DMG
-        working-directory: ./apps/desktop/src-tauri
-        shell: bash
-        run: |
-          cargo tauri build --bundles dmg --target ${{ matrix.arch == 'arm64' && 'aarch64-apple-darwin' || 'x86_64-apple-darwin' }} --no-dev
+          # Override beforeBuildCommand to empty since web is pre-built
+          cargo tauri build --bundles dmg --target ${{ matrix.arch == 'arm64' && 'aarch64-apple-darwin' || 'x86_64-apple-darwin' }} --no-dev --ci --config '{"build":{"beforeBuildCommand":""}}'
 
       - name: Find DMG
         id: dmg


### PR DESCRIPTION
## Summary

修复 CI 构建失败的根因：

- **根因**: `cargo tauri build` 会自动执行 `beforeBuildCommand: "pnpm build"`，导致重新构建 web 并可能因 workspace 依赖解析失败而报错
- **解法**: 使用 `cargo tauri build --config '{"build":{"beforeBuildCommand":""}}'` 覆盖为空，跳过 web 重建

## Workflow 结构

```
build-web (ubuntu)
  └── pnpm install → build core → build server → build frontend
  └── Upload: server-dist, frontend-dist

build-windows (windows-latest)
  └── Download artifacts
  └── cargo tauri build --config '{"build":{"beforeBuildCommand":""}}' --bundles msi

build-macos (macos-latest) × 2 (arm64, x64)
  └── Download artifacts
  └── cargo tauri build --config '{"build":{"beforeBuildCommand":""}}' --bundles dmg

release
  └── Download all → Create GitHub Release
```

## Test plan

- [ ] 打 tag 触发 CI
- [ ] build-web 成功
- [ ] build-windows / build-macos 成功
- [ ] Release 包含 .msi + .dmg × 2

Closes #45