### PR TITLE
refactor: 全部内置工具统一 harness 包装 + 安全修复

### DIFF
--- a/openspec/changes/archive/2026-04-01-tool-harness-migration/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-01-tool-harness-migration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-01

--- a/openspec/changes/archive/2026-04-01-tool-harness-migration/design.md
+++ b/openspec/changes/archive/2026-04-01-tool-harness-migration/design.md
@@ -1,0 +1,73 @@
+## Context
+
+Hive 的工具系统已有 harness 层（`tools/harness/`），提供了 ToolResult 结构化返回、错误码分类（TRANSIENT/RECOVERABLE/BLOCKED）、瞬态错误自动重试和 hint 注入。目前 bash-tool 和 file-tool 已接入，但其余 6 个工具仍直接使用 AI SDK `tool()` 返回 string。
+
+现有模式（bash/file 为例）：
+```
+createRawXxxTool() → RawTool (execute → ToolResult)
+createXxxTool()     → withHarness(createRawXxxTool()) → AI SDK Tool (execute → string)
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+- 6 个工具全部接入 harness，统一错误处理和重试机制
+- 网络类工具（send-file、web-search、web-fetch）瞬态错误自动重试
+- 本地类工具（glob、grep）结构化错误码 + hint 注入
+- ask-user 接入 harness，统一错误格式
+- 导出 `createRaw*Tool()` 供单元测试验证 ToolResult
+
+**Non-Goals:**
+- 不修改 harness 核心逻辑
+- 不改变工具对外 API 签名
+- 不修改 bash-tool 和 file-tool
+
+## Decisions
+
+### D1: 改造模式统一为 RawTool + withHarness
+
+每个工具拆分为：
+- `createRawXxxTool()` — 内部函数，execute 返回 `ToolResult`
+- `createXxxTool()` — 公开函数，用 `withHarness()` 包装
+
+与现有 bash-tool 和 file-tool 保持一致。
+
+### D2: 错误码映射
+
+| 工具 | 场景 | 错误码 | 分类 |
+|------|------|--------|------|
+| send-file | 飞书 API 失败 (400/429/5xx) | NETWORK | TRANSIENT (重试) |
+| send-file | 文件不存在 | NOT_FOUND | RECOVERABLE |
+| send-file | 无回调注册 | PERMISSION | RECOVERABLE |
+| send-file | channel 不支持 | PERMISSION | RECOVERABLE |
+| web-search | HTTP 失败 | NETWORK | TRANSIENT (重试) |
+| web-search | 无结果 | OK | — |
+| web-fetch | HTTP 失败 | NETWORK | TRANSIENT (重试) |
+| web-fetch | SSRF/内网 | PATH_BLOCKED | BLOCKED |
+| web-fetch | URL scheme 错误 | INVALID_PARAM | RECOVERABLE |
+| web-fetch | 内容为空 | NOT_FOUND | RECOVERABLE |
+| glob | 路径越界 | PATH_BLOCKED | BLOCKED |
+| glob | 无结果 | OK | — |
+| grep | 路径越界 | PATH_BLOCKED | BLOCKED |
+| grep | 正则错误 | INVALID_PARAM | RECOVERABLE |
+| grep | 无匹配 | OK | — |
+| ask-user | 无回调注册 | PERMISSION | RECOVERABLE |
+| ask-user | 回调异常 | EXEC_ERROR | RECOVERABLE |
+
+### D3: 网络工具重试配置
+
+send-file、web-search、web-fetch 通过 harness 的 `maxRetries: 2, baseDelay: 500` 配置获得自动重试。本地工具（glob、grep、ask-user）使用默认配置（不重试 TRANSIENT，只做 hint 注入）。
+
+### D4: 新增 hint 模板
+
+在 `hint-registry.ts` 中新增 `SEND_FILE_HINTS`、`WEB_SEARCH_HINTS`、`WEB_FETCH_HINTS`，覆盖网络失败、权限缺失等场景。
+
+### D5: 导出更新
+
+`built-in/index.ts` 新增导出 `createRawSendFileTool`、`createRawWebSearchTool`、`createRawWebFetchTool`、`createRawGlobTool`、`createRawGrepTool`、`createRawAskUserTool`。
+
+## Risks / Trade-offs
+
+- **[序列化格式变化]** harness serializer 输出 `[OK]`/`[Error]`/`[Security]`/`[Hint]` 前缀，与工具当前手写的格式可能略有差异。→ LLM 对这些前缀已有认知（bash/file 已在用），影响极小。
+- **[测试适配]** 现有工具测试断言的是 string 格式，需适配新的序列化输出。→ 改动量小，主要是前缀格式统一。
+- **[ask-user 重试]** ask-user 是用户交互工具，不应重试。→ 通过不返回 TRANSIENT 错误码实现（回调异常返回 EXEC_ERROR，属于 RECOVERABLE）。

--- a/openspec/changes/archive/2026-04-01-tool-harness-migration/proposal.md
+++ b/openspec/changes/archive/2026-04-01-tool-harness-migration/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+当前 6 个内置工具（send-file、web-search、web-fetch、glob、grep、ask-user）直接使用 AI SDK `tool()` 返回 string，没有经过 harness 层。这意味着它们缺少统一的错误码分类、hint 注入和瞬态错误自动重试。实际表现：send-file 调飞书 API 返回 400 时直接失败，LLM 不会重试，用户收到"文件发送遇到问题"。
+
+## What Changes
+
+- 将 6 个未接入 harness 的内置工具改造为 `createRaw*Tool()` + `withHarness()` 模式
+- 每个工具的 execute 返回 `ToolResult`（结构化错误码），由 harness 统一序列化为 string
+- 网络类工具（send-file、web-search、web-fetch）的瞬态错误自动重试
+- 新增 send-file、web-search、web-fetch 的 hint 模板
+- 导出 `createRaw*Tool()` 供单元测试直接验证 ToolResult
+
+## Non-goals
+
+- 不修改已接入 harness 的 bash-tool 和 file-tool
+- 不修改 harness 核心逻辑（retry、serializer、withHarness）
+- 不改变工具的对外 API（createXxxTool 签名不变）
+- 不引入新的依赖
+
+## Capabilities
+
+### New Capabilities
+
+（无新 capability）
+
+### Modified Capabilities
+
+- `builtin-tools`: 新增 6 个工具的 ToolResult 返回、错误码映射和 hint 模板
+- `tool-registry`: 工具注册方式从直接工厂改为 harness 包装后的工厂
+- `send-file-tool`: 接入 harness，网络错误自动重试
+
+## Impact
+
+- **packages/core**: `tools/built-in/` 下 6 个工具文件改造，`tools/built-in/index.ts` 导出更新
+- **packages/core**: `tools/harness/hint-registry.ts` 新增 hint 模板
+- **packages/core**: 单元测试需要适配 ToolResult 返回格式
+- **无破坏性变更**: 对外 API（createXxxTool、导出类型）保持不变

--- a/openspec/changes/archive/2026-04-01-tool-harness-migration/specs/builtin-tools/spec.md
+++ b/openspec/changes/archive/2026-04-01-tool-harness-migration/specs/builtin-tools/spec.md
@@ -1,0 +1,98 @@
+## MODIFIED Requirements
+
+### Requirement: Glob tool for file pattern matching
+系统 SHALL 提供 `glob` 内置工具，支持按 glob 模式搜索文件路径。工具 SHALL 接受 `pattern` 字符串参数（如 `**/*.ts`、`src/**/*.py`）。返回值 SHALL 为匹配的文件路径列表，按修改时间排序。结果超过 `maxResults`（默认 100）时 SHALL 截断。工具 SHALL 通过 harness 层包装，execute 函数返回 `ToolResult`，由 harness 序列化为 string。
+
+#### Scenario: Match TypeScript files
+- **WHEN** Agent 调用 glob 工具，pattern 为 "**/*.ts"
+- **THEN** 工具 SHALL 返回所有 .ts 文件的路径列表
+
+#### Scenario: No matches
+- **WHEN** Agent 调用 glob 工具，pattern 为 "**/*.xyz"
+- **THEN** 工具 SHALL 返回空数组
+
+#### Scenario: Result truncation
+- **WHEN** 匹配结果超过 100 个文件
+- **THEN** 工具 SHALL 返回前 100 个结果 + "[共 N 个匹配，已截断]"
+
+#### Scenario: Path blocked by security
+- **WHEN** Agent 调用 glob 工具，path 指向不允许的工作目录外
+- **THEN** 工具 SHALL 返回 `PATH_BLOCKED` 错误码和 hint 提示
+
+### Requirement: Grep tool for content search
+系统 SHALL 提供 `grep` 内置工具，支持用正则表达式搜索文件内容。工具 SHALL 接受 `pattern`（正则表达式）和可选的 `path`（搜索目录）、`glob`（文件类型过滤，如 `*.ts`）、`maxResults`（最大结果数，默认 50）参数。返回值 SHALL 包含匹配的文件路径、行号和匹配内容。工具 SHALL 通过 harness 层包装，execute 函数返回 `ToolResult`，由 harness 序列化为 string。
+
+#### Scenario: Search for function definition
+- **WHEN** Agent 调用 grep 工具，pattern 为 "function handleSubmit"
+- **THEN** 工具 SHALL 返回包含该模式的所有文件路径、行号和匹配行内容
+
+#### Scenario: Search with file type filter
+- **WHEN** Agent 调用 grep 工具，pattern 为 "import.*React"，glob 为 "*.tsx"
+- **THEN** 工具 SHALL 只搜索 .tsx 文件
+
+#### Scenario: Case insensitive search
+- **WHEN** Agent 调用 grep 工具，pattern 为 "TODO"，caseInsensitive 为 true
+- **THEN** 工具 SHALL 匹配 "TODO"、"todo"、"Todo" 等变体
+
+#### Scenario: Path blocked by security
+- **WHEN** Agent 调用 grep 工具，path 指向不允许的工作目录外
+- **THEN** 工具 SHALL 返回 `PATH_BLOCKED` 错误码和 hint 提示
+
+#### Scenario: Invalid regex pattern
+- **WHEN** Agent 调用 grep 工具，pattern 为无效正则表达式
+- **THEN** 工具 SHALL 返回 `INVALID_PARAM` 错误码和 hint 提示
+
+### Requirement: Web search tool using DuckDuckGo Lite
+系统 SHALL 提供 `web-search` 内置工具，使用 DuckDuckGo Lite 搜索网页。工具 SHALL 接受 `query` 字符串参数。工具 SHALL 抓取 `https://lite.duckduckgo.com/lite/?q=...` 的 HTML 页面，解析搜索结果（标题、URL、摘要）。工具 SHALL 通过 harness 层包装，execute 函数返回 `ToolResult`，由 harness 序列化为 string。网络错误 SHALL 返回 `NETWORK` 错误码，触发 harness 自动重试（最多 2 次，指数退避）。
+
+#### Scenario: Successful web search
+- **WHEN** Agent 调用 web-search 工具，query 为 "TypeScript 5.0 new features"
+- **THEN** 工具 SHALL 返回搜索结果数组，每项包含 title、url、snippet
+
+#### Scenario: No results found
+- **WHEN** Agent 调用 web-search 工具，query 为无意义字符串
+- **THEN** 工具 SHALL 返回空结果
+
+#### Scenario: Network error with auto-retry
+- **WHEN** DuckDuckGo Lite 请求失败（HTTP 5xx、网络超时等）
+- **THEN** 工具 SHALL 返回 `NETWORK` 错误码
+- **AND** harness SHALL 自动重试最多 2 次（指数退避 500ms、1000ms）
+
+### Requirement: Web fetch tool for URL content retrieval
+系统 SHALL 提供 `web-fetch` 内置工具，抓取指定 URL 的网页内容并转换为 Markdown。工具 SHALL 接受 `url` 字符串参数和可选的 `maxChars`（默认 30000）参数。工具 SHALL 使用 fetch 获取 HTML，用 cheerio 去除噪音元素，用 turndown 转换为 Markdown。工具 SHALL 通过 harness 层包装，execute 函数返回 `ToolResult`，由 harness 序列化为 string。HTTP 错误 SHALL 返回 `NETWORK` 错误码，触发自动重试。
+
+#### Scenario: Fetch and convert webpage
+- **WHEN** Agent 调用 web-fetch 工具，url 为 "https://example.com/docs"
+- **THEN** 工具 SHALL 返回该页面的 Markdown 格式内容
+
+#### Scenario: Content truncation
+- **WHEN** 页面 Markdown 内容超过 maxChars
+- **THEN** 工具 SHALL 截断并附加截断提示
+
+#### Scenario: Invalid URL
+- **WHEN** Agent 调用 web-fetch 工具，url 为 "not-a-url"
+- **THEN** 工具 SHALL 返回 `INVALID_PARAM` 错误码和 hint
+
+#### Scenario: SSRF blocked
+- **WHEN** Agent 调用 web-fetch 工具，url 指向内网地址
+- **THEN** 工具 SHALL 返回 `PATH_BLOCKED` 错误码
+
+#### Scenario: HTTP error with auto-retry
+- **WHEN** URL 请求返回 5xx 或网络错误
+- **THEN** 工具 SHALL 返回 `NETWORK` 错误码
+- **AND** harness SHALL 自动重试最多 2 次
+
+### Requirement: Ask user tool for clarification
+系统 SHALL 提供 `ask-user` 内置工具，允许 Agent 向用户提出澄清问题。工具 SHALL 接受 `question`（问题文本）和可选的 `options`（多选选项数组）参数。工具 SHALL 通过 harness 层包装，execute 函数返回 `ToolResult`，由 harness 序列化为 string。无回调注册时 SHALL 返回 `PERMISSION` 错误码。回调异常时 SHALL 返回 `EXEC_ERROR` 错误码。ask-user 不触发自动重试。
+
+#### Scenario: Ask question with options
+- **WHEN** Agent 调用 ask-user 工具，提供 question 和 options
+- **THEN** 工具 SHALL 通过回调传递问题，返回用户回答
+
+#### Scenario: No callback registered
+- **WHEN** ask-user 工具被调用但未注册回调
+- **THEN** 工具 SHALL 返回 `PERMISSION` 错误码和 hint
+
+#### Scenario: Callback error
+- **WHEN** 回调函数抛出异常
+- **THEN** 工具 SHALL 返回 `EXEC_ERROR` 错误码

--- a/openspec/changes/archive/2026-04-01-tool-harness-migration/specs/send-file-tool/spec.md
+++ b/openspec/changes/archive/2026-04-01-tool-harness-migration/specs/send-file-tool/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: send_file 内置工具
+系统 SHALL 提供 `send_file` 内置工具，允许 Agent 将本地文件发送给当前会话用户。工具 SHALL 通过 harness 层包装，execute 函数返回 `ToolResult`，由 harness 序列化为 string。网络类错误（飞书 API 400/429/5xx）SHALL 返回 `NETWORK` 错误码，触发 harness 自动重试（最多 2 次，指数退避）。
+
+#### Scenario: 发送文件
+- **WHEN** Agent 调用 `send_file` 并提供有效的本地文件路径
+- **THEN** 系统 SHALL 通过当前会话对应的 channel 发送文件消息
+- **AND** 返回成功信息（包含文件名）
+
+#### Scenario: 发送图片
+- **WHEN** Agent 调用 `send_file` 且文件路径指向图片
+- **THEN** 系统 SHALL 自动识别为图片类型并发送
+
+#### Scenario: 文件不存在
+- **WHEN** Agent 调用 `send_file` 但文件路径不存在
+- **THEN** 系统 SHALL 返回 `NOT_FOUND` 错误码和 hint
+
+#### Scenario: 无回调注册
+- **WHEN** Agent 调用 `send_file` 但未注入发送回调
+- **THEN** 系统 SHALL 返回 `PERMISSION` 错误码和 hint
+
+#### Scenario: Channel 不支持文件发送
+- **WHEN** 当前会话的 channel 不支持 `sendFile` 能力
+- **THEN** 系统 SHALL 返回 `PERMISSION` 错误码和 hint
+
+#### Scenario: 飞书 API 失败自动重试
+- **WHEN** 飞书 API 返回 400/429/5xx 错误
+- **THEN** 工具 SHALL 返回 `NETWORK` 错误码
+- **AND** harness SHALL 自动重试最多 2 次（指数退避 500ms、1000ms）
+
+#### Scenario: 工具仅分配给 general Agent
+- **WHEN** 创建 `explore` 或 `plan` Agent 的工具集
+- **THEN** 工具集中 SHALL 不包含 `send_file`

--- a/openspec/changes/archive/2026-04-01-tool-harness-migration/tasks.md
+++ b/openspec/changes/archive/2026-04-01-tool-harness-migration/tasks.md
@@ -1,0 +1,57 @@
+## 1. Hint 模板
+
+- [x] 1.1 在 `hint-registry.ts` 中新增 `SEND_FILE_HINTS` 模板（NETWORK、NOT_FOUND、PERMISSION）
+- [x] 1.2 在 `hint-registry.ts` 中新增 `WEB_SEARCH_HINTS` 模板（NETWORK）
+- [x] 1.3 在 `hint-registry.ts` 中新增 `WEB_FETCH_HINTS` 模板（NETWORK、PATH_BLOCKED、INVALID_PARAM、NOT_FOUND）
+- [x] 1.4 在 `hint-registry.ts` 中新增 `GLOB_HINTS` 模板（PATH_BLOCKED）
+- [x] 1.5 在 `hint-registry.ts` 中新增 `GREP_HINTS` 模板（PATH_BLOCKED、INVALID_PARAM）
+- [x] 1.6 在 `hint-registry.ts` 中新增 `ASK_USER_HINTS` 模板（PERMISSION、EXEC_ERROR）
+- [x] 1.7 更新 `getAllHintTemplates()` 合并新模板
+
+## 2. send-file-tool 改造
+
+- [x] 2.1 创建 `createRawSendFileTool()`，execute 返回 `ToolResult`，错误码映射（NETWORK/NOT_FOUND/PERMISSION）
+- [x] 2.2 修改 `createSendFileTool()` 为 `withHarness(createRawSendFileTool(), { maxRetries: 2, baseDelay: 500 })`
+- [x] 2.3 更新 `built-in/index.ts` 导出 `createRawSendFileTool`
+- [x] 2.4 运行现有 send-file 测试，验证通过
+
+## 3. web-search-tool 改造
+
+- [x] 3.1 创建 `createRawWebSearchTool()`，execute 返回 `ToolResult`，错误码映射（NETWORK）
+- [x] 3.2 修改 `createWebSearchTool()` 为 `withHarness(createRawWebSearchTool(), { maxRetries: 2, baseDelay: 500 })`
+- [x] 3.3 更新 `built-in/index.ts` 导出 `createRawWebSearchTool`
+- [x] 3.4 运行测试验证
+
+## 4. web-fetch-tool 改造
+
+- [x] 4.1 创建 `createRawWebFetchTool()`，execute 返回 `ToolResult`，错误码映射（NETWORK/PATH_BLOCKED/INVALID_PARAM/NOT_FOUND）
+- [x] 4.2 修改 `createWebFetchTool()` 为 `withHarness(createRawWebFetchTool(), { maxRetries: 2, baseDelay: 500 })`
+- [x] 4.3 更新 `built-in/index.ts` 导出 `createRawWebFetchTool`
+- [x] 4.4 运行测试验证
+
+## 5. glob-tool 改造
+
+- [x] 5.1 创建 `createRawGlobTool()`，execute 返回 `ToolResult`，错误码映射（PATH_BLOCKED）
+- [x] 5.2 修改 `createGlobTool()` 为 `withHarness(createRawGlobTool())`
+- [x] 5.3 更新 `built-in/index.ts` 导出 `createRawGlobTool`
+- [x] 5.4 运行测试验证
+
+## 6. grep-tool 改造
+
+- [x] 6.1 创建 `createRawGrepTool()`，execute 返回 `ToolResult`，错误码映射（PATH_BLOCKED/INVALID_PARAM）
+- [x] 6.2 修改 `createGrepTool()` 为 `withHarness(createRawGrepTool())`
+- [x] 6.3 更新 `built-in/index.ts` 导出 `createRawGrepTool`
+- [x] 6.4 运行测试验证
+
+## 7. ask-user-tool 改造
+
+- [x] 7.1 创建 `createRawAskUserTool()`，execute 返回 `ToolResult`，错误码映射（PERMISSION/EXEC_ERROR）
+- [x] 7.2 修改 `createAskUserTool()` 为 `withHarness(createRawAskUserTool())`
+- [x] 7.3 更新 `built-in/index.ts` 导出 `createRawAskUserTool`
+- [x] 7.4 运行测试验证
+
+## 8. 全量验证
+
+- [x] 8.1 运行 core 全量单元测试 `pnpm --filter @bundy-lmw/hive-core test`
+- [x] 8.2 运行 server 全量测试 `vitest run --config vitest.config.ts tests/`
+- [x] 8.3 运行 `pnpm -r build` 确保编译通过

--- a/packages/core/src/server/ServerImpl.ts
+++ b/packages/core/src/server/ServerImpl.ts
@@ -363,7 +363,7 @@ class ServerImpl implements Server {
             return { success: false, error: `Channel ${sendChannelId} does not support file sending` };
           }
           try {
-            const result = await channel.send({ to: sendChatId, content: '', filePath });
+            const result = await channel.send({ to: sendChatId, content: '', filePath, type: 'file' });
             return { success: result.success, error: result.error };
           } catch (error) {
             return { success: false, error: error instanceof Error ? error.message : String(error) };

--- a/packages/core/src/tools/built-in/ask-user-tool.ts
+++ b/packages/core/src/tools/built-in/ask-user-tool.ts
@@ -5,8 +5,10 @@
  * 通过 ToolRegistry 注册的回调函数获取用户回答。
  */
 
-import { tool, zodSchema, type Tool } from 'ai';
+import { zodSchema, type Tool } from 'ai';
 import { z } from 'zod';
+import type { ToolResult } from '../harness/types.js';
+import { withHarness, type RawTool } from '../harness/with-harness.js';
 
 /** 用户提问回调函数类型 */
 export type AskUserCallback = (question: string, options?: Array<{ label: string; description?: string }>) => Promise<string>;
@@ -35,26 +37,37 @@ const askUserInputSchema = z.object({
 export type AskUserToolInput = z.infer<typeof askUserInputSchema>;
 
 /**
- * 创建 Ask User 工具
+ * 创建 Ask User rawTool（execute → ToolResult）
+ *
+ * 供 withHarness 包装使用，也供单元测试直接验证 ToolResult。
  */
-export function createAskUserTool(): Tool<AskUserToolInput, string> {
-  return tool({
+export function createRawAskUserTool(): RawTool<AskUserToolInput> {
+  return {
     description: '向用户提出问题以获取澄清信息或让用户做选择。适用于需要用户输入才能继续的场景。',
     inputSchema: zodSchema(askUserInputSchema),
-    execute: async ({ question, options }): Promise<string> => {
+    execute: async ({ question, options }): Promise<ToolResult> => {
       if (!askUserCallback) {
-        return '[ask-user] 无回调注册，无法向用户提问。请确保通过 ToolRegistry 注册了回调函数。';
+        return { ok: false, code: 'PERMISSION', error: '无回调注册，无法向用户提问', context: { reason: '无回调注册' } };
       }
 
       try {
         const answer = await askUserCallback(question, options);
-        return answer;
+        return { ok: true, code: 'OK', data: answer };
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        return `[Error] 获取用户回答失败: ${msg}`;
+        return { ok: false, code: 'EXEC_ERROR', error: `获取用户回答失败: ${msg}` };
       }
     },
-  });
+  };
+}
+
+/**
+ * 创建 Ask User 工具（AI SDK 兼容，execute → string）
+ *
+ * 内部使用 createRawAskUserTool + withHarness 包装。
+ */
+export function createAskUserTool(): Tool<AskUserToolInput, string> {
+  return withHarness(createRawAskUserTool(), { toolName: 'ask-user-tool' });
 }
 
 export const askUserTool = createAskUserTool();

--- a/packages/core/src/tools/built-in/bash-tool.ts
+++ b/packages/core/src/tools/built-in/bash-tool.ts
@@ -84,7 +84,15 @@ export function createRawBashTool(options?: BashToolOptions): RawTool<BashToolIn
                 (timeoutErr as any).killed = true;
                 reject(timeoutErr);
               } else {
-                resolve(stdout + stderr);
+                // 非零退出码：命令执行失败但未超时
+                const output = (stdout + stderr).trim();
+                const exitMsg = output
+                  ? `命令执行失败 (exit code ${error.code ?? '?'}): ${output}`
+                  : `命令执行失败 (exit code ${error.code ?? '?'}): ${error.message}`;
+                const execErr = new Error(exitMsg);
+                (execErr as any).exitCode = error.code;
+                (execErr as any).output = output;
+                reject(execErr);
               }
             } else {
               resolve(stdout + stderr);
@@ -125,7 +133,7 @@ export function createRawBashTool(options?: BashToolOptions): RawTool<BashToolIn
  * 内部使用 createRawBashTool + withHarness 包装。
  */
 export function createBashTool(options?: BashToolOptions): Tool<BashToolInput, string> {
-  return withHarness(createRawBashTool(options));
+  return withHarness(createRawBashTool(options), { toolName: 'bash-tool' });
 }
 
 /** 默认 Bash 工具实例（全权限） */

--- a/packages/core/src/tools/built-in/file-tool.ts
+++ b/packages/core/src/tools/built-in/file-tool.ts
@@ -157,7 +157,7 @@ export function createRawFileTool(options?: FileToolOptions): RawTool<FileToolIn
  * 内部使用 createRawFileTool + withHarness 包装。
  */
 export function createFileTool(options?: FileToolOptions): Tool<FileToolInput, string> {
-  return withHarness(createRawFileTool(options));
+  return withHarness(createRawFileTool(options), { toolName: 'file-tool' });
 }
 
 // ============================================

--- a/packages/core/src/tools/built-in/glob-tool.ts
+++ b/packages/core/src/tools/built-in/glob-tool.ts
@@ -7,9 +7,12 @@
 
 import { readdir, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
-import { tool, zodSchema, type Tool } from 'ai';
+import { zodSchema, type Tool } from 'ai';
 import { z } from 'zod';
 import { isPathAllowed } from './utils/security.js';
+import { truncateOutput } from './utils/output-safety.js';
+import type { ToolResult } from '../harness/types.js';
+import { withHarness, type RawTool } from '../harness/with-harness.js';
 
 /** 最大递归深度 */
 const MAX_DEPTH = 20;
@@ -71,11 +74,12 @@ async function simpleGlob(dir: string, pattern: string): Promise<string[]> {
 }
 
 function matchGlobPart(name: string, pattern: string): boolean {
-  const regex = pattern
-    .replace(/\./g, '\\.')
+  // 先转义所有正则元字符，再将 glob 特殊字符替换为对应的正则
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
     .replace(/\*/g, '.*')
     .replace(/\?/g, '.');
-  return new RegExp(`^${regex}$`).test(name);
+  return new RegExp(`^${escaped}$`).test(name);
 }
 
 /** Glob 工具输入 schema */
@@ -88,19 +92,21 @@ const globInputSchema = z.object({
 export type GlobToolInput = z.infer<typeof globInputSchema>;
 
 /**
- * 创建 Glob 工具
+ * 创建 Glob rawTool（execute → ToolResult）
+ *
+ * 供 withHarness 包装使用，也供单元测试直接验证 ToolResult。
  */
-export function createGlobTool(): Tool<GlobToolInput, string> {
-  return tool({
+export function createRawGlobTool(): RawTool<GlobToolInput> {
+  return {
     description: '按文件名模式搜索文件路径。支持 *（匹配任意字符）和 **（匹配目录层级）。返回匹配的文件路径列表。',
     inputSchema: zodSchema(globInputSchema),
-    execute: async ({ pattern, path: searchPath, maxResults }): Promise<string> => {
+    execute: async ({ pattern, path: searchPath, maxResults }): Promise<ToolResult> => {
       const max = maxResults ?? 100;
       const dir = resolve(searchPath || process.cwd());
 
       // 路径约束检查
       if (!isPathAllowed(dir)) {
-        return `[Security] 搜索路径不在允许的工作目录内: ${dir}`;
+        return { ok: false, code: 'PATH_BLOCKED', error: `搜索路径不在允许的工作目录内: ${dir}`, context: { path: dir } };
       }
 
       try {
@@ -121,21 +127,33 @@ export function createGlobTool(): Tool<GlobToolInput, string> {
         const sortedFiles = withStats.map(f => f.path);
 
         if (sortedFiles.length === 0) {
-          return `未找到匹配 "${pattern}" 的文件`;
+          return { ok: true, code: 'OK', data: `未找到匹配 "${pattern}" 的文件` };
         }
 
+        let output: string;
         if (sortedFiles.length > max) {
           const display = sortedFiles.slice(0, max);
-          return display.join('\n') + `\n\n[共 ${withStats.length} 个匹配，已截断显示前 ${max} 个]`;
+          output = display.join('\n') + `\n\n[共 ${withStats.length} 个匹配，已截断显示前 ${max} 个]`;
+        } else {
+          output = sortedFiles.join('\n');
         }
 
-        return sortedFiles.join('\n');
+        return { ok: true, code: 'OK', data: truncateOutput(output) };
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        return `[Error] 搜索失败: ${msg}`;
+        return { ok: false, code: 'EXEC_ERROR', error: `搜索失败: ${msg}` };
       }
     },
-  });
+  };
+}
+
+/**
+ * 创建 Glob 工具（AI SDK 兼容，execute → string）
+ *
+ * 内部使用 createRawGlobTool + withHarness 包装。
+ */
+export function createGlobTool(): Tool<GlobToolInput, string> {
+  return withHarness(createRawGlobTool(), { toolName: 'glob-tool' });
 }
 
 export const globTool = createGlobTool();

--- a/packages/core/src/tools/built-in/grep-tool.ts
+++ b/packages/core/src/tools/built-in/grep-tool.ts
@@ -7,10 +7,12 @@
 
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { join, resolve, extname } from 'node:path';
-import { tool, zodSchema, type Tool } from 'ai';
+import { zodSchema, type Tool } from 'ai';
 import { z } from 'zod';
 import { isPathAllowed } from './utils/security.js';
 import { truncateOutput } from './utils/output-safety.js';
+import type { ToolResult } from '../harness/types.js';
+import { withHarness, type RawTool } from '../harness/with-harness.js';
 
 /** 最大递归深度 */
 const MAX_DEPTH = 20;
@@ -80,23 +82,33 @@ async function collectFiles(dir: string, depth: number): Promise<string[]> {
 }
 
 /**
- * 创建 Grep 工具
+ * 创建 Grep rawTool（execute → ToolResult）
+ *
+ * 供 withHarness 包装使用，也供单元测试直接验证 ToolResult。
  */
-export function createGrepTool(): Tool<GrepToolInput, string> {
-  return tool({
+export function createRawGrepTool(): RawTool<GrepToolInput> {
+  return {
     description: '使用正则表达式搜索文件内容。返回匹配的文件路径、行号和匹配行。',
     inputSchema: zodSchema(grepInputSchema),
-    execute: async ({ pattern, path: searchPath, glob: globFilter, maxResults, caseInsensitive }): Promise<string> => {
+    execute: async ({ pattern, path: searchPath, glob: globFilter, maxResults, caseInsensitive }): Promise<ToolResult> => {
       const max = maxResults ?? 50;
       const dir = resolve(searchPath || process.cwd());
 
       // 路径约束检查
       if (!isPathAllowed(dir)) {
-        return `[Security] 搜索路径不在允许的工作目录内: ${dir}`;
+        return { ok: false, code: 'PATH_BLOCKED', error: `搜索路径不在允许的工作目录内: ${dir}`, context: { path: dir } };
+      }
+
+      // 正则表达式校验
+      let regex: RegExp;
+      try {
+        regex = new RegExp(pattern, caseInsensitive ? 'i' : '');
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        return { ok: false, code: 'INVALID_PARAM', error: `正则表达式无效: ${msg}`, context: { pattern } };
       }
 
       try {
-        const regex = new RegExp(pattern, caseInsensitive ? 'i' : '');
         const files = await collectFiles(dir, 0);
 
         const results: GrepResult[] = [];
@@ -123,7 +135,7 @@ export function createGrepTool(): Tool<GrepToolInput, string> {
         }
 
         if (results.length === 0) {
-          return `未找到匹配 "${pattern}" 的内容`;
+          return { ok: true, code: 'OK', data: `未找到匹配 "${pattern}" 的内容` };
         }
 
         const display = results.slice(0, max);
@@ -131,16 +143,25 @@ export function createGrepTool(): Tool<GrepToolInput, string> {
 
         const output = formatted.join('\n');
         if (results.length > max) {
-          return output + `\n\n[共 ${results.length} 个匹配，已截断显示前 ${max} 个]`;
+          return { ok: true, code: 'OK', data: truncateOutput(output + `\n\n[共 ${results.length} 个匹配，已截断显示前 ${max} 个]`) };
         }
 
-        return truncateOutput(output);
+        return { ok: true, code: 'OK', data: truncateOutput(output) };
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        return `[Error] 搜索失败: ${msg}`;
+        return { ok: false, code: 'EXEC_ERROR', error: `搜索失败: ${msg}` };
       }
     },
-  });
+  };
+}
+
+/**
+ * 创建 Grep 工具（AI SDK 兼容，execute → string）
+ *
+ * 内部使用 createRawGrepTool + withHarness 包装。
+ */
+export function createGrepTool(): Tool<GrepToolInput, string> {
+  return withHarness(createRawGrepTool(), { toolName: 'grep-tool' });
 }
 
 export const grepTool = createGrepTool();

--- a/packages/core/src/tools/built-in/index.ts
+++ b/packages/core/src/tools/built-in/index.ts
@@ -12,15 +12,17 @@ export type { BashToolOptions } from './bash-tool.js';
 export { createFileTool, createRawFileTool, fileTool, fileToolReadOnly } from './file-tool.js';
 export type { FileToolOptions } from './file-tool.js';
 
-export { createGlobTool, globTool } from './glob-tool.js';
-export { createGrepTool, grepTool } from './grep-tool.js';
-export { createWebSearchTool, webSearchTool } from './web-search-tool.js';
-export { createWebFetchTool, webFetchTool } from './web-fetch-tool.js';
-export { createAskUserTool, askUserTool, setAskUserCallback } from './ask-user-tool.js';
-export type { AskUserCallback } from './ask-user-tool.js';
+export { createGlobTool, createRawGlobTool, globTool } from './glob-tool.js';
+export { createGrepTool, createRawGrepTool, grepTool } from './grep-tool.js';
+export { createWebSearchTool, createRawWebSearchTool, webSearchTool } from './web-search-tool.js';
+export { createWebFetchTool, createRawWebFetchTool, webFetchTool } from './web-fetch-tool.js';
+export { createAskUserTool, createRawAskUserTool, askUserTool, setAskUserCallback } from './ask-user-tool.js';
+export type { AskUserCallback, AskUserToolInput } from './ask-user-tool.js';
 
-export { createSendFileTool, sendFileTool, setSendFileCallback } from './send-file-tool.js';
-export type { SendFileCallback } from './send-file-tool.js';
+export { createSendFileTool, createRawSendFileTool, sendFileTool, setSendFileCallback } from './send-file-tool.js';
+export type { SendFileCallback, SendFileToolInput } from './send-file-tool.js';
+export type { WebFetchToolInput } from './web-fetch-tool.js';
+export type { WebSearchToolInput } from './web-search-tool.js';
 
 // 子 Agent 工具
 export { createSubagentTool, createAllSubagentTools } from './subagent-tools.js';

--- a/packages/core/src/tools/built-in/send-file-tool.ts
+++ b/packages/core/src/tools/built-in/send-file-tool.ts
@@ -1,82 +1,117 @@
 /**
  * Send File 工具 — 将本地文件发送给当前会话用户
  *
- * 使用 AI SDK tool() + Zod schema 定义。
+ * 通过 AI SDK tool() + Zod schema 定义。
  * 通过 ToolRegistry 注入的回调函数执行发送。
  */
 
-import { tool, zodSchema, type Tool } from 'ai'
-import { z } from 'zod'
-import fs from 'fs'
-import path from 'path'
+import { zodSchema, type Tool } from 'ai';
+import { z } from 'zod';
+import fs from 'fs';
+import path from 'path';
+import { isPathAllowed, isSensitiveFile } from './utils/security.js';
+import type { ToolResult } from '../harness/types.js';
+import { withHarness, type RawTool } from '../harness/with-harness.js';
 
 /** 发送文件回调函数类型 */
-export type SendFileCallback = (filePath: string) => Promise<{ success: boolean; error?: string }>
+export type SendFileCallback = (filePath: string) => Promise<{ success: boolean; error?: string }>;
 
 /** 全局回调（由 ToolRegistry 注入） */
-let sendFileCallback: SendFileCallback | null = null
+let sendFileCallback: SendFileCallback | null = null;
 
 /**
  * 设置发送文件回调
  */
 export function setSendFileCallback(cb: SendFileCallback): void {
-  sendFileCallback = cb
+  sendFileCallback = cb;
 }
 
 /** 图片扩展名 */
-const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg'])
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg']);
 
 /** Send File 工具输入 schema */
 const sendFileInputSchema = z.object({
   filePath: z.string().describe('要发送的本地文件路径（绝对路径或相对于工作目录的路径）'),
   description: z.string().optional().describe('文件描述，会作为发送消息的附言'),
-})
+});
 
-export type SendFileToolInput = z.infer<typeof sendFileInputSchema>
+export type SendFileToolInput = z.infer<typeof sendFileInputSchema>;
 
 /**
- * 创建 Send File 工具
+ * 创建 Send File rawTool（execute → ToolResult）
+ *
+ * 供 withHarness 包装使用，也供单元测试直接验证 ToolResult。
  */
-export function createSendFileTool(): Tool<SendFileToolInput, string> {
-  return tool({
+export function createRawSendFileTool(): RawTool<SendFileToolInput> {
+  return {
     description: '将本地文件发送给当前会话的用户。支持文件和图片。适用于：用户要求发送文件、分享生成的报告、转发下载的资源等场景。',
     inputSchema: zodSchema(sendFileInputSchema),
-    execute: async ({ filePath, description }): Promise<string> => {
+    execute: async ({ filePath, description }): Promise<ToolResult> => {
       if (!sendFileCallback) {
-        return '[send_file] 当前环境不支持文件发送。仅在通过消息通道（如飞书）接入时可用。'
+        return { ok: false, code: 'PERMISSION', error: '当前环境不支持文件发送。仅在通过消息通道（如飞书）接入时可用。', context: { reason: '无回调注册' } };
       }
 
-      const absolutePath = path.resolve(filePath)
+      const absolutePath = path.resolve(filePath);
+
+      // 路径约束检查
+      if (!isPathAllowed(absolutePath)) {
+        return { ok: false, code: 'PATH_BLOCKED', error: `文件路径不在允许的工作目录内: ${absolutePath}`, context: { path: absolutePath } };
+      }
+
+      // 敏感文件检查
+      const sensitive = isSensitiveFile(absolutePath, 'read');
+      if (sensitive.sensitive) {
+        return { ok: false, code: 'SENSITIVE_FILE', error: `拒绝发送敏感文件（${sensitive.description}）`, context: { description: sensitive.description } };
+      }
 
       // 检查文件是否存在
       if (!fs.existsSync(absolutePath)) {
-        return `[Error] 文件不存在: ${absolutePath}`
+        return { ok: false, code: 'NOT_FOUND', error: `文件不存在: ${absolutePath}`, context: { path: absolutePath } };
       }
 
       // 检查是否为目录
-      const stat = fs.statSync(absolutePath)
+      const stat = fs.statSync(absolutePath);
       if (stat.isDirectory()) {
-        return `[Error] 不能发送目录: ${absolutePath}`
+        return { ok: false, code: 'NOT_FOUND', error: `不能发送目录: ${absolutePath}`, context: { path: absolutePath } };
       }
 
       try {
-        const result = await sendFileCallback(absolutePath)
+        const result = await sendFileCallback(absolutePath);
         if (!result.success) {
-          return `[Error] 文件发送失败: ${result.error || '未知错误'}`
+          // 检查是否为网络错误（可重试）
+          const msg = result.error ?? '未知错误';
+          const isNetwork = /400|429|5\d{2}|timeout|ECONNREFUSED|ENOTFOUND/i.test(msg);
+          if (isNetwork) {
+            return { ok: false, code: 'NETWORK', error: `文件发送失败: ${msg}`, context: { status: msg } };
+          }
+          return { ok: false, code: 'EXEC_ERROR', error: `文件发送失败: ${msg}` };
         }
 
-        const ext = path.extname(absolutePath).toLowerCase()
-        const fileType = IMAGE_EXTENSIONS.has(ext) ? '图片' : '文件'
-        const fileName = path.basename(absolutePath)
-        const descriptionText = description ? `\n${description}` : ''
+        const ext = path.extname(absolutePath).toLowerCase();
+        const fileType = IMAGE_EXTENSIONS.has(ext) ? '图片' : '文件';
+        const fileName = path.basename(absolutePath);
+        const descriptionText = description ? `\n${description}` : '';
 
-        return `已发送${fileType}: ${fileName}${descriptionText}`
+        return { ok: true, code: 'OK', data: `已发送${fileType}: ${fileName}${descriptionText}` };
       } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error)
-        return `[Error] 文件发送失败: ${msg}`
+        const msg = error instanceof Error ? error.message : String(error);
+        const isNetwork = /timeout|ECONNREFUSED|ENOTFOUND/i.test(msg);
+        if (isNetwork) {
+          return { ok: false, code: 'NETWORK', error: `文件发送失败: ${msg}`, context: { status: msg } };
+        }
+        return { ok: false, code: 'EXEC_ERROR', error: `文件发送失败: ${msg}` };
       }
     },
-  })
+  };
 }
 
-export const sendFileTool = createSendFileTool()
+/**
+ * 创建 Send File 工具（AI SDK 兼容，execute → string）
+ *
+ * 内部使用 createRawSendFileTool + withHarness 包装。
+ */
+export function createSendFileTool(): Tool<SendFileToolInput, string> {
+  return withHarness(createRawSendFileTool(), { maxRetries: 2, baseDelay: 500, toolName: 'send-file-tool' });
+}
+
+export const sendFileTool = createSendFileTool();

--- a/packages/core/src/tools/built-in/utils/security.ts
+++ b/packages/core/src/tools/built-in/utils/security.ts
@@ -5,7 +5,8 @@
  * 包含：危险命令检查、敏感文件检查、路径约束、SSRF 防护、命令策略校验。
  */
 
-import { resolve, isAbsolute, relative } from 'node:path';
+import { resolve, isAbsolute, relative, basename } from 'node:path';
+import dns from 'node:dns';
 
 // ============================================
 // 常量
@@ -51,14 +52,16 @@ interface SensitivePattern {
 }
 
 const SENSITIVE_FILES: SensitivePattern[] = [
-  { pattern: /\.env(\.|$)/, description: '环境变量文件', allowRead: false, allowWrite: false },
+  // 基于文件名的模式（使用 basename 匹配，避免路径片段误匹配）
+  { pattern: /^\.env(\.|$)/, description: '环境变量文件', allowRead: false, allowWrite: false },
+  { pattern: /^id_rsa(\.|$)/, description: 'SSH 私钥', allowRead: false, allowWrite: false },
+  { pattern: /^id_ed25519(\.|$)/, description: 'ED25519 私钥', allowRead: false, allowWrite: false },
+  { pattern: /\.pem$/i, description: 'PEM 证书', allowRead: false, allowWrite: false },
+  { pattern: /\.key$/i, description: '密钥文件', allowRead: false, allowWrite: false },
+  { pattern: /^credentials(\.\w+)?\.json$/i, description: '凭证文件', allowRead: false, allowWrite: false },
+  { pattern: /^secret(s)?\.(json|yaml|yml)$/i, description: '机密配置', allowRead: false, allowWrite: false },
+  // 基于路径的模式（检查完整路径）
   { pattern: /\/\.ssh\//, description: 'SSH 密钥目录', allowRead: false, allowWrite: false },
-  { pattern: /id_rsa(\.|$)/, description: 'SSH 私钥', allowRead: false, allowWrite: false },
-  { pattern: /id_ed25519(\.|$)/, description: 'ED25519 私钥', allowRead: false, allowWrite: false },
-  { pattern: /\.pem(\.|$)/, description: 'PEM 证书', allowRead: false, allowWrite: false },
-  { pattern: /\.key(\.|$)/, description: '密钥文件', allowRead: false, allowWrite: false },
-  { pattern: /credentials\.json$/, description: '凭证文件', allowRead: false, allowWrite: false },
-  { pattern: /secrets?\.(json|yaml|yml)$/, description: '机密配置', allowRead: false, allowWrite: false },
   { pattern: /\/etc\/passwd$/, description: '系统密码文件', allowRead: false, allowWrite: false },
   { pattern: /\/etc\/shadow$/, description: '系统影子密码文件', allowRead: false, allowWrite: false },
 ];
@@ -111,17 +114,49 @@ export function isPathAllowed(filePath: string): boolean {
 // ============================================
 
 /**
+ * 检查 IP 地址是否为私网/保留地址
+ *
+ * 覆盖范围：RFC 1918 私网、loopback、link-local、IPv6 本地。
+ */
+function isPrivateAddress(ip: string): boolean {
+  // IPv4
+  if (/^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(ip)) return true;
+  if (/^127\./.test(ip)) return true;
+  if (/^169\.254\./.test(ip)) return true;
+  if (/^0\./.test(ip)) return true;
+  if (/^22[4-9]\./.test(ip) || /^23[0-9]\./.test(ip)) return true; // 224.0.0.0/4 组播/保留
+
+  // IPv6
+  if (ip === '::1' || ip === '::') return true;
+  if (/^fe80:/i.test(ip)) return true;   // link-local
+  if (/^fc00:/i.test(ip) || /^fd00:/i.test(ip)) return true; // ULA
+
+  return false;
+}
+
+/**
  * 检查 hostname 是否解析到私有 IP
  *
- * TODO: 当前策略不基于私网地址做拦截，统一返回 false。
- * 应实现 RFC 1918 范围检测（10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16）及 loopback。
+ * 通过 DNS 解析 hostname，检查所有解析结果是否为私网地址。
  */
-export async function isPrivateIP(
-  hostname: string,
-  _resolvers?: unknown,
-): Promise<boolean> {
-  void hostname;
-  return false;
+export async function isPrivateIP(hostname: string): Promise<boolean> {
+  try {
+    const addresses = await dns.promises.resolve4(hostname);
+    return addresses.some(addr => isPrivateAddress(addr));
+  } catch {
+    // DNS 解析失败（如非域名），检查是否为 IP 字面量
+    if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname)) {
+      return isPrivateAddress(hostname);
+    }
+    // IPv6 字面量检查
+    if (/^::1$/.test(hostname) || /^::$/.test(hostname)) {
+      return true;
+    }
+    if (/^fe80:/i.test(hostname) || /^fc00:/i.test(hostname) || /^fd00:/i.test(hostname)) {
+      return true;
+    }
+    return false;
+  }
 }
 
 /**
@@ -182,11 +217,19 @@ export function isDangerousCommand(command: string): { dangerous: boolean; descr
  * 检查文件路径是否敏感
  */
 export function isSensitiveFile(filePath: string, operation: 'read' | 'write'): { sensitive: boolean; description?: string } {
-  const match = SENSITIVE_FILES.find(p => p.pattern.test(filePath));
-  if (match) {
-    const allowed = operation === 'read' ? match.allowRead : match.allowWrite;
-    if (!allowed) {
-      return { sensitive: true, description: match.description };
+  const fileName = basename(filePath);
+
+  for (const p of SENSITIVE_FILES) {
+    // 路径级模式（包含 /）用完整路径匹配
+    // 文件名级模式（以 ^ 或 \. 开头/结尾）用 basename 匹配
+    const isPathPattern = p.pattern.source.includes('/');
+    const target = isPathPattern ? filePath : fileName;
+
+    if (p.pattern.test(target)) {
+      const allowed = operation === 'read' ? p.allowRead : p.allowWrite;
+      if (!allowed) {
+        return { sensitive: true, description: p.description };
+      }
     }
   }
   return { sensitive: false };

--- a/packages/core/src/tools/built-in/web-fetch-tool.ts
+++ b/packages/core/src/tools/built-in/web-fetch-tool.ts
@@ -6,12 +6,14 @@
  * 内置 SSRF 防护：仅允许 HTTPS，拒绝内网 IP。
  */
 
-import { tool, zodSchema, type Tool } from 'ai';
+import { zodSchema, type Tool } from 'ai';
 import { z } from 'zod';
 import * as cheerio from 'cheerio';
 import TurndownService from 'turndown';
 import { truncateOutput } from './utils/output-safety.js';
 import { isAllowedUrl, isPrivateIP } from './utils/security.js';
+import type { ToolResult } from '../harness/types.js';
+import { withHarness, type RawTool } from '../harness/with-harness.js';
 
 const turndown = new TurndownService({
   headingStyle: 'atx',
@@ -35,25 +37,27 @@ const webFetchInputSchema = z.object({
 export type WebFetchToolInput = z.infer<typeof webFetchInputSchema>;
 
 /**
- * 创建 Web Fetch 工具
+ * 创建 Web Fetch rawTool（execute → ToolResult）
+ *
+ * 供 withHarness 包装使用，也供单元测试直接验证 ToolResult。
  */
-export function createWebFetchTool(): Tool<WebFetchToolInput, string> {
-  return tool({
+export function createRawWebFetchTool(): RawTool<WebFetchToolInput> {
+  return {
     description: '获取指定 URL 的网页内容并转换为 Markdown 格式。自动去除导航、广告等噪音元素。适用于抓取文档页面、博客文章等。仅允许 HTTPS URL。',
     inputSchema: zodSchema(webFetchInputSchema),
-    execute: async ({ url, maxChars }): Promise<string> => {
+    execute: async ({ url, maxChars }): Promise<ToolResult> => {
       try {
         // URL scheme 校验
         const urlCheck = isAllowedUrl(url);
         if (!urlCheck.allowed) {
-          return `[Security] ${urlCheck.reason}`;
+          return { ok: false, code: 'INVALID_PARAM', error: urlCheck.reason, context: { url } };
         }
 
         // SSRF 检查：拒绝内网 IP
         const hostname = new URL(url).hostname;
         const privateCheck = await isPrivateIP(hostname);
         if (privateCheck) {
-          return `[Security] 拒绝访问内网地址: ${hostname}`;
+          return { ok: false, code: 'PATH_BLOCKED', error: `拒绝访问内网地址: ${hostname}` };
         }
 
         const response = await fetch(url, {
@@ -65,7 +69,7 @@ export function createWebFetchTool(): Tool<WebFetchToolInput, string> {
         });
 
         if (!response.ok) {
-          return `[Error] 请求失败 (HTTP ${response.status})`;
+          return { ok: false, code: 'NETWORK', error: `请求失败 (HTTP ${response.status})`, context: { status: String(response.status) } };
         }
 
         const html = await response.text();
@@ -81,16 +85,29 @@ export function createWebFetchTool(): Tool<WebFetchToolInput, string> {
         const markdown = turndown.turndown(bodyHtml);
 
         if (!markdown.trim()) {
-          return `[Error] 页面内容为空`;
+          return { ok: false, code: 'NOT_FOUND', error: '页面内容为空' };
         }
 
-        return truncateOutput(markdown, maxChars);
+        return { ok: true, code: 'OK', data: truncateOutput(markdown, maxChars) };
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        return `[Error] 抓取失败: ${msg}`;
+        const isNetwork = /timeout|ECONNREFUSED|ENOTFOUND/i.test(msg);
+        if (isNetwork) {
+          return { ok: false, code: 'NETWORK', error: `抓取失败: ${msg}` };
+        }
+        return { ok: false, code: 'EXEC_ERROR', error: `抓取失败: ${msg}` };
       }
     },
-  });
+  };
+}
+
+/**
+ * 创建 Web Fetch 工具（AI SDK 兼容，execute → string）
+ *
+ * 内部使用 createRawWebFetchTool + withHarness 包装。
+ */
+export function createWebFetchTool(): Tool<WebFetchToolInput, string> {
+  return withHarness(createRawWebFetchTool(), { maxRetries: 2, baseDelay: 500, toolName: 'web-fetch-tool' });
 }
 
 export const webFetchTool = createWebFetchTool();

--- a/packages/core/src/tools/built-in/web-search-tool.ts
+++ b/packages/core/src/tools/built-in/web-search-tool.ts
@@ -5,9 +5,11 @@
  * 免费搜索，无需 API key。
  */
 
-import { tool, zodSchema, type Tool } from 'ai';
+import { zodSchema, type Tool } from 'ai';
 import { z } from 'zod';
 import { truncateOutput } from './utils/output-safety.js';
+import type { ToolResult } from '../harness/types.js';
+import { withHarness, type RawTool } from '../harness/with-harness.js';
 
 interface SearchResult {
   title: string;
@@ -48,13 +50,15 @@ const webSearchInputSchema = z.object({
 export type WebSearchToolInput = z.infer<typeof webSearchInputSchema>;
 
 /**
- * 创建 Web Search 工具
+ * 创建 Web Search rawTool（execute → ToolResult）
+ *
+ * 供 withHarness 包装使用，也供单元测试直接验证 ToolResult。
  */
-export function createWebSearchTool(): Tool<WebSearchToolInput, string> {
-  return tool({
+export function createRawWebSearchTool(): RawTool<WebSearchToolInput> {
+  return {
     description: '搜索网页获取最新信息。使用 DuckDuckGo 搜索引擎，返回标题、URL 和摘要。搜索结果可能不包含最新内容，建议结合 web-fetch 工具获取完整页面内容。',
     inputSchema: zodSchema(webSearchInputSchema),
-    execute: async ({ query, maxResults }): Promise<string> => {
+    execute: async ({ query, maxResults }): Promise<ToolResult> => {
       try {
         const encoded = encodeURIComponent(query);
         const url = `https://lite.duckduckgo.com/lite/?q=${encoded}`;
@@ -68,14 +72,14 @@ export function createWebSearchTool(): Tool<WebSearchToolInput, string> {
         });
 
         if (!response.ok) {
-          return `[Error] 搜索请求失败 (HTTP ${response.status})`;
+          return { ok: false, code: 'NETWORK', error: `搜索请求失败 (HTTP ${response.status})`, context: { status: String(response.status) } };
         }
 
         const html = await response.text();
         const results = await parseDuckDuckGoLite(html);
 
         if (results.length === 0) {
-          return `未找到 "${query}" 的搜索结果`;
+          return { ok: true, code: 'OK', data: `未找到 "${query}" 的搜索结果` };
         }
 
         const max = Math.min(maxResults ?? MAX_SEARCH_RESULTS, MAX_SEARCH_RESULTS);
@@ -88,13 +92,26 @@ export function createWebSearchTool(): Tool<WebSearchToolInput, string> {
           ? `\n\n[共 ${results.length} 个结果，已截断显示前 ${max} 个]`
           : '';
 
-        return truncateOutput(output + suffix);
+        return { ok: true, code: 'OK', data: truncateOutput(output + suffix) };
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        return `[Error] 搜索失败: ${msg}`;
+        const isNetwork = /timeout|ECONNREFUSED|ENOTFOUND/i.test(msg);
+        if (isNetwork) {
+          return { ok: false, code: 'NETWORK', error: `搜索失败: ${msg}` };
+        }
+        return { ok: false, code: 'EXEC_ERROR', error: `搜索失败: ${msg}` };
       }
     },
-  });
+  };
+}
+
+/**
+ * 创建 Web Search 工具（AI SDK 兼容，execute → string）
+ *
+ * 内部使用 createRawWebSearchTool + withHarness 包装。
+ */
+export function createWebSearchTool(): Tool<WebSearchToolInput, string> {
+  return withHarness(createRawWebSearchTool(), { maxRetries: 2, baseDelay: 500, toolName: 'web-search-tool' });
 }
 
 export const webSearchTool = createWebSearchTool();

--- a/packages/core/src/tools/harness/hint-registry.ts
+++ b/packages/core/src/tools/harness/hint-registry.ts
@@ -73,13 +73,114 @@ const BASH_HINTS: HintTemplateMap = {
 };
 
 // ============================================
-// 合并注册表
+// send-file-tool hint 模板
 // ============================================
 
-const ALL_HINTS: HintTemplateMap = { ...FILE_HINTS, ...BASH_HINTS };
+const SEND_FILE_HINTS: HintTemplateMap = {
+  NETWORK: (ctx) =>
+    `建议: 文件发送失败（网络错误: ${ctx.status ?? '未知'}）。` +
+    `系统将自动重试。如果持续失败，请检查网络连接或稍后重试。`,
+
+  NOT_FOUND: (ctx) =>
+    `建议: 文件不存在（${ctx.path ?? '未知路径'}）。` +
+    `请先确认文件路径是否正确。`,
+
+  PERMISSION: (ctx) =>
+    `建议: 当前环境不支持文件发送（${ctx.reason ?? '无回调注册'}）。` +
+    `文件发送仅在通过消息通道（如飞书）接入时可用。`,
+};
+
+// ============================================
+// web-search-tool hint 模板
+// ============================================
+
+const WEB_SEARCH_HINTS: HintTemplateMap = {
+  NETWORK: () =>
+    `建议: 搜索请求失败（网络错误）。系统将自动重试。` +
+    `如果持续失败，可以尝试换一个搜索词或稍后重试。`,
+};
+
+// ============================================
+// web-fetch-tool hint 模板
+// ============================================
+
+const WEB_FETCH_HINTS: HintTemplateMap = {
+  NETWORK: (ctx) =>
+    `建议: 页面抓取失败（HTTP ${ctx.status ?? '未知'}）。系统将自动重试。` +
+    `如果持续失败，可以尝试直接访问该 URL 或稍后重试。`,
+
+  PATH_BLOCKED: () =>
+    `建议: 拒绝访问内网地址，这是安全策略限制。` +
+    `请使用公网 URL。`,
+
+  INVALID_PARAM: (ctx) =>
+    `建议: URL 格式无效（${ctx.url ?? ''}）。` +
+    `请提供完整的 HTTPS URL（如 https://example.com）。`,
+
+  NOT_FOUND: () =>
+    `建议: 页面内容为空。可能是页面需要 JavaScript 渲染或有反爬机制。` +
+    `可以尝试直接访问该 URL 确认。`,
+};
+
+// ============================================
+// glob-tool hint 模板
+// ============================================
+
+const GLOB_HINTS: HintTemplateMap = {
+  PATH_BLOCKED: (ctx) =>
+    `建议: 搜索路径 ${ctx.path ?? ''} 不在允许的工作目录内。` +
+    `请选择工作空间目录下的路径。`,
+};
+
+// ============================================
+// grep-tool hint 模板
+// ============================================
+
+const GREP_HINTS: HintTemplateMap = {
+  PATH_BLOCKED: (ctx) =>
+    `建议: 搜索路径 ${ctx.path ?? ''} 不在允许的工作目录内。` +
+    `请选择工作空间目录下的路径。`,
+
+  INVALID_PARAM: (ctx) =>
+    `建议: 正则表达式无效（${ctx.pattern ?? ''}）。` +
+    `请检查正则语法是否正确。`,
+};
+
+// ============================================
+// ask-user-tool hint 模板
+// ============================================
+
+const ASK_USER_HINTS: HintTemplateMap = {
+  PERMISSION: () =>
+    `建议: 当前环境不支持向用户提问。请确保通过 ToolRegistry 注册了回调函数。`,
+
+  EXEC_ERROR: () =>
+    `建议: 获取用户回答失败。请检查回调函数是否正常工作。`,
+};
+
+// ============================================
+// 按工具分组注册（用于 getHint(toolName, code, context)）
+// ============================================
+
+const TOOL_HINT_MAP: Record<string, HintTemplateMap> = {
+  'file-tool': FILE_HINTS,
+  'bash-tool': BASH_HINTS,
+  'send-file-tool': SEND_FILE_HINTS,
+  'web-search-tool': WEB_SEARCH_HINTS,
+  'web-fetch-tool': WEB_FETCH_HINTS,
+  'glob-tool': GLOB_HINTS,
+  'grep-tool': GREP_HINTS,
+  'ask-user-tool': ASK_USER_HINTS,
+};
+
+// ============================================
+// 全局合并（仅包含不冲突的 key，FILE_HINTS 作为默认）
+// ============================================
+
+const ALL_HINTS: HintTemplateMap = { ...BASH_HINTS, ...SEND_FILE_HINTS, ...WEB_SEARCH_HINTS, ...WEB_FETCH_HINTS, ...GLOB_HINTS, ...GREP_HINTS, ...ASK_USER_HINTS, ...FILE_HINTS };
 
 /**
- * 根据错误码和上下文获取 hint
+ * 根据错误码和上下文获取 hint（兼容旧 API）
  *
  * @returns hint 字符串，如果无对应模板则返回 undefined
  */
@@ -93,10 +194,39 @@ export function getHint(
 }
 
 /**
+ * 根据工具名和错误码获取 hint
+ *
+ * 优先从指定工具的模板查找，回退到全局 ALL_HINTS。
+ *
+ * @param toolName - 工具名（如 'file-tool', 'grep-tool'）
+ * @param code - 错误码
+ * @param context - 上下文变量
+ * @returns hint 字符串，如果无对应模板则返回 undefined
+ */
+export function getHintForTool(
+  toolName: string,
+  code: string,
+  context: Record<string, unknown> = {},
+): string | undefined {
+  // 优先从指定工具的模板查找
+  const toolTemplate = TOOL_HINT_MAP[toolName]?.[code];
+  if (toolTemplate) return toolTemplate(context);
+  // 回退到全局
+  return getHint(code, context);
+}
+
+/**
+ * 获取指定工具的 hint 模板
+ */
+export function getToolHintTemplates(toolName: string): HintTemplateMap {
+  return TOOL_HINT_MAP[toolName] ?? {};
+}
+
+/**
  * 获取所有 hint 模板（用于 withHarness 默认配置）
  */
 export function getAllHintTemplates(): HintTemplateMap {
   return { ...ALL_HINTS };
 }
 
-export { FILE_HINTS, BASH_HINTS };
+export { FILE_HINTS, BASH_HINTS, SEND_FILE_HINTS, WEB_SEARCH_HINTS, WEB_FETCH_HINTS, GLOB_HINTS, GREP_HINTS, ASK_USER_HINTS };

--- a/packages/core/src/tools/harness/serializer.ts
+++ b/packages/core/src/tools/harness/serializer.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ToolResult, HintTemplateMap } from './types.js';
-import { getHint } from './hint-registry.js';
+import { getHintForTool } from './hint-registry.js';
 import { BLOCKED_CODES } from './types.js';
 
 /**
@@ -14,10 +14,12 @@ import { BLOCKED_CODES } from './types.js';
  *
  * @param result - 工具返回的 ToolResult
  * @param customTemplates - 自定义 hint 模板（合并到默认模板之上）
+ * @param toolName - 工具名（用于 hint 查找回退）
  */
 export function serializeToolResult(
   result: ToolResult,
   customTemplates?: HintTemplateMap,
+  toolName?: string,
 ): string {
   const prefix = result.ok ? '[OK]' : getSecurityPrefix(result.code);
   const lines: string[] = [];
@@ -31,7 +33,7 @@ export function serializeToolResult(
   lines.push(`${prefix} ${result.error ?? 'Unknown error'}`.trim());
 
   // 生成 hint
-  const hint = result.hint ?? resolveHint(result.code, result.context, customTemplates);
+  const hint = result.hint ?? resolveHint(result.code, result.context, customTemplates, toolName);
   if (hint) {
     lines.push(`[Hint] ${hint}`);
   }
@@ -53,11 +55,15 @@ function resolveHint(
   code: string,
   context: Record<string, unknown> | undefined,
   customTemplates?: HintTemplateMap,
+  toolName?: string,
 ): string | undefined {
   // 优先使用自定义模板
   if (customTemplates?.[code]) {
     return customTemplates[code](context ?? {});
   }
-  // 回退到全局模板
-  return getHint(code, context);
+  // 回退到按工具查找 hint
+  if (toolName) {
+    return getHintForTool(toolName, code, context);
+  }
+  return undefined;
 }

--- a/packages/core/src/tools/harness/types.ts
+++ b/packages/core/src/tools/harness/types.ts
@@ -84,7 +84,9 @@ export interface RetryConfig {
 }
 
 export interface HarnessConfig extends RetryConfig {
-  /** 自定义 hint 模板 */
+  /** 工具名称（用于从 hint-registry 按工具查找 hint 模板） */
+  toolName?: string;
+  /** 自定义 hint 模板（优先级最高，覆盖 toolName 和全局模板） */
   hintTemplates?: HintTemplateMap;
 }
 

--- a/packages/core/src/tools/harness/with-harness.ts
+++ b/packages/core/src/tools/harness/with-harness.ts
@@ -9,7 +9,7 @@ import { tool, type Tool } from 'ai';
 import type { ToolResult, HarnessConfig, HintTemplateMap } from './types.js';
 import { retryWithBackoff } from './retry.js';
 import { serializeToolResult } from './serializer.js';
-import { getAllHintTemplates } from './hint-registry.js';
+import { getAllHintTemplates, getToolHintTemplates } from './hint-registry.js';
 
 /**
  * RawTool 类型 — execute 返回 ToolResult
@@ -32,8 +32,11 @@ export function withHarness<TInput = any>(
   rawTool: RawTool<TInput>,
   config?: HarnessConfig,
 ): Tool<TInput, string> {
+  // 合并 hint 模板：全局 < 工具级 < 自定义
+  const toolTemplates = config?.toolName ? getToolHintTemplates(config.toolName) : {};
   const mergedTemplates: HintTemplateMap = {
     ...getAllHintTemplates(),
+    ...toolTemplates,
     ...config?.hintTemplates,
   };
 
@@ -46,7 +49,7 @@ export function withHarness<TInput = any>(
       );
 
       // 2. 序列化为 string（内部处理 hint injection）
-      return serializeToolResult(result, mergedTemplates);
+      return serializeToolResult(result, mergedTemplates, config?.toolName);
     } catch (error) {
       // 3. 异常兜底 — 确保永远返回 string
       const msg = error instanceof Error ? error.message : String(error);

--- a/packages/core/tests/unit/tools/bash-tool.test.ts
+++ b/packages/core/tests/unit/tools/bash-tool.test.ts
@@ -208,18 +208,19 @@ describe('createRawBashTool', () => {
       expect(result.context).toHaveProperty('timeout', 1000);
     });
 
-    it('should return ToolResult for OK when command exits non-zero but has output', async () => {
+    it('should return EXEC_ERROR when command exits non-zero', async () => {
       mockExec.mockImplementation((cmd: string, opts: any, cb: any) => {
         const err = new Error('command not found');
+        (err as any).code = 127;
         cb(err, '', 'command not found');
       });
       const tool = createRawBashTool({ allowed: true });
       const result = await tool.execute!({ command: 'nonexistent_cmd', timeout: 5000 }, {} as any) as ToolResult;
 
-      // Non-killed errors resolve with stdout+stderr (bash convention: non-zero exit is output, not failure)
-      expect(result).toHaveProperty('ok', true);
-      expect(result).toHaveProperty('code', 'OK');
-      expect(result.data).toContain('command not found');
+      expect(result).toHaveProperty('ok', false);
+      expect(result).toHaveProperty('code', 'EXEC_ERROR');
+      expect(result.error).toContain('命令执行失败');
+      expect(result.error).toContain('command not found');
     });
   });
 });

--- a/packages/core/tests/unit/tools/harness-integration.test.ts
+++ b/packages/core/tests/unit/tools/harness-integration.test.ts
@@ -50,9 +50,10 @@ afterEach(() => {
 async function pipeline<TInput>(
   rawTool: RawTool<TInput>,
   input: TInput,
+  toolName?: string,
 ): Promise<string> {
   const result: ToolResult = await rawTool.execute(input, {});
-  return serializeToolResult(result);
+  return serializeToolResult(result, undefined, toolName);
 }
 
 // ============================================
@@ -62,23 +63,23 @@ async function pipeline<TInput>(
 describe('BashTool harness integration', () => {
   it('should return [OK] for successful command', async () => {
     const rawTool = createRawBashTool({ allowed: true });
-    const output = await pipeline(rawTool, { command: 'echo hello' });
+    const output = await pipeline(rawTool, { command: 'echo hello' }, 'bash-tool');
 
     expect(output).toContain('[OK]');
     expect(output).toContain('hello');
   });
 
-  it('should return output for non-zero exit code commands', async () => {
+  it('should return [Error] for non-zero exit code commands', async () => {
     const rawTool = createRawBashTool({ allowed: true });
-    const output = await pipeline(rawTool, { command: 'ls /nonexistent-path-xyz-12345' });
+    const output = await pipeline(rawTool, { command: 'ls /nonexistent-path-xyz-12345' }, 'bash-tool');
 
-    // 非零退出码，stderr 合并到 stdout，bash-tool 仍然返回 ok: true
-    expect(output).toContain('[OK]');
+    expect(output).toContain('[Error]');
+    expect(output).toContain('命令执行失败');
   });
 
   it('should block dangerous commands with [Security] + [Hint]', async () => {
     const rawTool = createRawBashTool({ allowed: true });
-    const output = await pipeline(rawTool, { command: 'rm -rf /' });
+    const output = await pipeline(rawTool, { command: 'rm -rf /' }, 'bash-tool');
 
     expect(output).toContain('[Security]');
     expect(output).toContain('阻止危险命令');
@@ -87,7 +88,7 @@ describe('BashTool harness integration', () => {
 
   it('should block commands when allowed=false with [Permission]', async () => {
     const rawTool = createRawBashTool({ allowed: false });
-    const output = await pipeline(rawTool, { command: 'echo hello' });
+    const output = await pipeline(rawTool, { command: 'echo hello' }, 'bash-tool');
 
     expect(output).toContain('[Permission]');
     expect(output).toContain('无权限');
@@ -106,7 +107,7 @@ describe('FileTool harness integration', () => {
       command: 'create',
       file_path: filePath,
       content: 'hello world',
-    });
+    }, 'file-tool');
 
     expect(output).toContain('[OK]');
     expect(output).toContain('创建');
@@ -127,7 +128,7 @@ describe('FileTool harness integration', () => {
     const output = await pipeline(rawTool, {
       command: 'view',
       file_path: filePath,
-    });
+    }, 'file-tool');
 
     expect(output).toContain('[OK]');
     expect(output).toContain('line1');
@@ -151,7 +152,7 @@ describe('FileTool harness integration', () => {
       file_path: filePath,
       old_str: 'hello',
       new_str: 'goodbye',
-    });
+    }, 'file-tool');
 
     expect(output).toContain('[OK]');
     expect(output).toContain('替换');
@@ -174,7 +175,7 @@ describe('FileTool harness integration', () => {
       file_path: filePath,
       old_str: 'nonexistent_text',
       new_str: 'replacement',
-    });
+    }, 'file-tool');
 
     expect(output).toContain('[Error]');
     expect(output).toContain('未找到');
@@ -187,7 +188,7 @@ describe('FileTool harness integration', () => {
     const output = await pipeline(rawTool, {
       command: 'view',
       file_path: join(tempDir, 'nonexistent.txt'),
-    });
+    }, 'file-tool');
 
     expect(output).toContain('[Error]');
     expect(output).toContain('[Hint]');
@@ -201,10 +202,10 @@ describe('FileTool harness integration', () => {
       command: 'create',
       file_path: join(sshDir, 'id_rsa'),
       content: 'malicious',
-    });
+    }, 'file-tool');
 
     expect(output).toContain('[Security]');
-    expect(output).toContain('SSH 密钥');
+    expect(output).toContain('SSH');
     expect(output).toContain('[Hint]');
   });
 
@@ -215,7 +216,7 @@ describe('FileTool harness integration', () => {
       command: 'create',
       file_path: filePath,
       content: 'test',
-    });
+    }, 'file-tool');
 
     expect(output).toContain('[Permission]');
     expect(output).toContain('[Hint]');
@@ -290,7 +291,7 @@ describe('FileTool additional coverage', () => {
       file_path: filePath,
       insert_line: 1,
       insert_text: 'line2',
-    });
+    }, 'file-tool');
 
     expect(output).toContain('[OK]');
     expect(output).toContain('插入');
@@ -311,7 +312,7 @@ describe('FileTool additional coverage', () => {
       file_path: filePath,
       offset: 2,
       limit: 2,
-    });
+    }, 'file-tool');
 
     expect(output).toContain('[OK]');
     expect(output).toContain('line2');
@@ -336,7 +337,7 @@ describe('FileTool additional coverage', () => {
       file_path: filePath,
       old_str: 'aaa',
       new_str: 'xxx',
-    });
+    }, 'file-tool');
 
     expect(output).toContain('[Error]');
     expect(output).toContain('处匹配');
@@ -357,7 +358,7 @@ describe('FileTool additional coverage', () => {
       file_path: filePath,
       insert_line: 99,
       insert_text: 'new line',
-    });
+    }, 'file-tool');
 
     expect(output).toContain('[Error]');
     expect(output).toContain('超出范围');
@@ -370,7 +371,7 @@ describe('FileTool additional coverage', () => {
     const output = await pipeline(rawTool, {
       command: 'view',
       file_path: '/dev/null/impossible',
-    });
+    }, 'file-tool');
 
     // 可能是 PATH_BLOCKED 或 IO_ERROR，只要不是崩溃就行
     expect(typeof output).toBe('string');

--- a/packages/core/tests/unit/tools/harness.test.ts
+++ b/packages/core/tests/unit/tools/harness.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { serializeToolResult } from '../../../src/tools/harness/serializer.js';
-import { getHint } from '../../../src/tools/harness/hint-registry.js';
+import { getHint, getAllHintTemplates } from '../../../src/tools/harness/hint-registry.js';
 import { isRetryable, retryWithBackoff } from '../../../src/tools/harness/retry.js';
 import { withHarness } from '../../../src/tools/harness/with-harness.js';
 import type { ToolResult } from '../../../src/tools/harness/types.js';
@@ -50,7 +50,7 @@ describe('serializeToolResult', () => {
       code: 'OK',
       data: '文件已创建: /path/to/file.ts',
     };
-    const output = serializeToolResult(result);
+    const output = serializeToolResult(result, getAllHintTemplates());
     expect(output).toContain('[OK]');
     expect(output).toContain('文件已创建');
     expect(output).not.toContain('[Hint]');
@@ -63,7 +63,7 @@ describe('serializeToolResult', () => {
       error: '未找到要替换的文本',
       context: { path: '/path/to/file.ts' },
     };
-    const output = serializeToolResult(result);
+    const output = serializeToolResult(result, getAllHintTemplates());
     expect(output).toContain('[Error]');
     expect(output).toContain('未找到要替换的文本');
     expect(output).toContain('[Hint]');
@@ -87,7 +87,7 @@ describe('serializeToolResult', () => {
       error: '阻止写入敏感文件: SSH 密钥目录',
       context: { path: '/home/user/.ssh/id_rsa', description: 'SSH 密钥目录' },
     };
-    const output = serializeToolResult(result);
+    const output = serializeToolResult(result, getAllHintTemplates());
     expect(output).toContain('[Security]');
     expect(output).toContain('[Hint]');
   });
@@ -99,7 +99,7 @@ describe('serializeToolResult', () => {
       error: '阻止危险命令: 递归删除根目录',
       context: { command: 'rm -rf /', description: '递归删除根目录' },
     };
-    const output = serializeToolResult(result);
+    const output = serializeToolResult(result, getAllHintTemplates());
     expect(output).toContain('[Security]');
     expect(output).toContain('[Hint]');
   });
@@ -111,7 +111,7 @@ describe('serializeToolResult', () => {
       error: '命令被策略阻止: /usr/bin/evil',
       context: { command: '/usr/bin/evil' },
     };
-    const output = serializeToolResult(result);
+    const output = serializeToolResult(result, getAllHintTemplates());
     expect(output).toContain('[Security]');
     expect(output).toContain('[Hint]');
   });
@@ -124,7 +124,7 @@ describe('serializeToolResult', () => {
       context: { path: '/path/to/file.ts' },
       hint: '自定义提示: 请检查缩进',
     };
-    const output = serializeToolResult(result);
+    const output = serializeToolResult(result, getAllHintTemplates());
     expect(output).toContain('[Hint]');
     expect(output).toContain('自定义提示: 请检查缩进');
   });
@@ -136,7 +136,7 @@ describe('serializeToolResult', () => {
       error: '当前 Agent 无权限执行 create 操作',
       context: { command: 'create' },
     };
-    const output = serializeToolResult(result);
+    const output = serializeToolResult(result, getAllHintTemplates());
     expect(output).toContain('[Permission]');
   });
 
@@ -147,7 +147,7 @@ describe('serializeToolResult', () => {
       error: '找到 3 处匹配，无法确定替换位置',
       context: { path: '/path/to/file.ts', matchCount: 3 },
     };
-    const output = serializeToolResult(result);
+    const output = serializeToolResult(result, getAllHintTemplates());
     expect(output).toContain('[Error]');
     expect(output).toContain('[Hint]');
   });

--- a/packages/core/tests/unit/tools/security.test.ts
+++ b/packages/core/tests/unit/tools/security.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import dns from 'node:dns';
 import {
   isPathAllowed,
   isPrivateIP,
@@ -63,54 +64,52 @@ describe('isPathAllowed', () => {
 });
 
 describe('isPrivateIP', () => {
-  const mockResolve4 = vi.fn<[string], Promise<string[]>>();
-  const mockResolve6 = vi.fn<[string], Promise<string[]>>();
-  const resolvers = { resolve4: mockResolve4, resolve6: mockResolve6 };
-
   beforeEach(() => {
-    vi.clearAllMocks();
-    mockResolve4.mockResolvedValue([]);
-    mockResolve6.mockResolvedValue([]);
+    vi.restoreAllMocks();
   });
 
-  it('should not block localhost addresses', async () => {
-    mockResolve4.mockResolvedValue(['127.0.0.1']);
-    expect(await isPrivateIP('localhost', resolvers)).toBe(false);
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('should not block private RFC1918 ranges', async () => {
-    mockResolve4.mockResolvedValue(['10.0.1.1']);
-    expect(await isPrivateIP('internal.corp', resolvers)).toBe(false);
+  it('should block localhost addresses', async () => {
+    vi.spyOn(dns.promises, 'resolve4').mockResolvedValue(['127.0.0.1']);
+    expect(await isPrivateIP('localhost')).toBe(true);
   });
 
-  it('should not block 172.16.0.0/12', async () => {
-    mockResolve4.mockResolvedValue(['172.20.0.1']);
-    expect(await isPrivateIP('private.host', resolvers)).toBe(false);
+  it('should block private RFC1918 ranges (10.x.x.x)', async () => {
+    vi.spyOn(dns.promises, 'resolve4').mockResolvedValue(['10.0.1.1']);
+    expect(await isPrivateIP('internal.corp')).toBe(true);
   });
 
-  it('should not block 192.168.0.0/16', async () => {
-    mockResolve4.mockResolvedValue(['192.168.1.1']);
-    expect(await isPrivateIP('home.local', resolvers)).toBe(false);
+  it('should block 172.16.0.0/12', async () => {
+    vi.spyOn(dns.promises, 'resolve4').mockResolvedValue(['172.20.0.1']);
+    expect(await isPrivateIP('private.host')).toBe(true);
   });
 
-  it('should not block link-local addresses', async () => {
-    mockResolve4.mockResolvedValue(['169.254.1.1']);
-    expect(await isPrivateIP('link.local', resolvers)).toBe(false);
+  it('should block 192.168.0.0/16', async () => {
+    vi.spyOn(dns.promises, 'resolve4').mockResolvedValue(['192.168.1.1']);
+    expect(await isPrivateIP('home.local')).toBe(true);
   });
 
-  it('should not block loopback IPv6', async () => {
-    mockResolve6.mockResolvedValue(['::1']);
-    expect(await isPrivateIP('localhost6', resolvers)).toBe(false);
+  it('should block link-local addresses', async () => {
+    vi.spyOn(dns.promises, 'resolve4').mockResolvedValue(['169.254.1.1']);
+    expect(await isPrivateIP('link.local')).toBe(true);
+  });
+
+  it('should block IPv6 loopback', async () => {
+    vi.spyOn(dns.promises, 'resolve4').mockRejectedValue(new Error('ENOTFOUND'));
+    expect(await isPrivateIP('::1')).toBe(true);
   });
 
   it('should allow public IPs', async () => {
-    mockResolve4.mockResolvedValue(['93.184.216.34']);
-    expect(await isPrivateIP('example.com', resolvers)).toBe(false);
+    vi.spyOn(dns.promises, 'resolve4').mockResolvedValue(['93.184.216.34']);
+    expect(await isPrivateIP('example.com')).toBe(false);
   });
 
   it('should return false on DNS failure (conservative)', async () => {
-    mockResolve4.mockRejectedValue(new Error('ENOTFOUND'));
-    expect(await isPrivateIP('nonexistent.xyz', resolvers)).toBe(false);
+    vi.spyOn(dns.promises, 'resolve4').mockRejectedValue(new Error('ENOTFOUND'));
+    expect(await isPrivateIP('nonexistent.xyz')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- 6 个内置工具迁移到 withHarness 模式（send-file/web-search/web-fetch/glob/grep/ask-user），统一 ToolResult 错误码、自动重试和 hint 注入
- 实现 isPrivateIP SSRF 防护（RFC 1918 + IPv6 loopback/link-local）
- 修复 Bash 工具非零退出码返回 ok:true 的 bug
- 修复敏感文件匹配绕过（.key 匹配 monkey.txt），改用 basename 精确匹配
- send-file-tool 添加 isPathAllowed + isSensitiveFile 路径约束
- glob-tool matchGlobPart 修复正则注入（转义所有元字符）
- hint-registry 支持按工具分组查找（getHintForTool），消除模板覆盖
- 修复 ServerImpl sendFileCallback 缺少 type:file 导致飞书 API 400

## Test plan
- [x] pnpm --filter @bundy-lmw/hive-core test (66 files, 1128 tests passed)
- [x] vitest run --config vitest.config.ts tests/ (13 files, 166 tests passed)
- [x] pnpm -r build 编译通过

Closes #67