### PR TITLE
ci: release workflow 简化为单架构 ARM64 构建

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,20 +6,10 @@ on:
 
 permissions:
   contents: write
-  releases: write
 
 jobs:
   build-macos:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-14
-            arch: arm64
-          - os: macos-14
-            arch: x64
-
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- 移除 matrix 双架构构建（`macos-` 空值 bug + x64 交叉编译不生效），改为单一 `macos-14` ARM64 构建
- 移除无效的 `releases: write` 权限（`contents: write` 已覆盖 release 操作）

## Test plan
- [x] pnpm test 通过（66 文件，1128 用例）
- [ ] push tag 触发 Release CI 验证

Closes #70