### PR TITLE
feat: Agent 对话中注入定时任务能力感知

### DIFF
--- a/openspec/changes/archive/2026-04-01-schedule-awareness/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-01-schedule-awareness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-01

--- a/openspec/changes/archive/2026-04-01-schedule-awareness/design.md
+++ b/openspec/changes/archive/2026-04-01-schedule-awareness/design.md
@@ -1,0 +1,62 @@
+## Context
+
+Hive Agent 使用 `DynamicPromptBuilder` 构建 system prompt，由多个 section 组成：base template → language → task → environment → history → context → skill。ScheduleCapability 已作为内部模块注册到 AgentContext，但 LLM 在对话中无法感知其存在。
+
+当前定时任务触发链路：用户消息 → ScheduleCapability 关键词预过滤 → LLM 结构化输出 → 用户确认 → 创建任务。这条链路完全依赖关键词匹配，Agent 不会主动建议创建定时任务。
+
+## Goals / Non-Goals
+
+**Goals:**
+- LLM 在对话中知道 Agent 具备定时任务能力（创建、查询、管理）
+- LLM 能感知到当前已有的定时任务列表（上下文感知）
+- 通过 prompt 注入实现，不引入新的 Tool 或修改 ScheduleCapability 内部逻辑
+
+**Non-Goals:**
+- 不注册 schedule-related Tool 函数（避免 ToolRegistry 污染）
+- 不修改 ScheduleEngine 调度逻辑
+- 不修改 ScheduleCapability 的 4 层防幻觉机制
+- 不改变定时任务的持久化或生命周期管理
+
+## Decisions
+
+### Decision 1: 独立 prompt 模板文件
+
+**选择**: 新增 `templates/schedule-awareness.md`，在 `DynamicPromptBuilder.buildSections()` 中作为独立 section 注入。
+
+**替代方案**:
+- A) 修改 `intelligent.md` 在 "Your Capabilities" 下追加 — 拒绝，因为 intelligent.md 是通用的 Agent 角色模板，不应该耦合业务能力
+- B) 通过 SkillCapability 的 skill section 注入 — 拒绝，定时任务是核心能力而非可插拔技能
+
+**理由**: 独立文件符合 templates/ 目录的职责划分（tool-guides.md 也是独立文件），且可以在 token budget 紧张时单独裁剪。
+
+### Decision 2: 注入已有任务摘要
+
+**选择**: 在构建 schedule section 时，查询 ScheduleRepository 获取已有任务列表，格式化为摘要嵌入 prompt。
+
+**替代方案**:
+- A) 不注入，让 Agent 通过自然语言触发 ScheduleCapability 的 listSchedules — 拒绝，这要求用户主动问，Agent 仍然是被动的
+- B) 注入完整任务详情 — 拒绝，token 消耗过大
+
+**理由**: 摘要让 Agent 具备"上下文感知"，能在对话中主动提及已有任务（如"你已有一个每天9点的日志检查任务，需要修改吗？"）。摘要限制为名称 + 调度模式 + 状态，控制 token 消耗。
+
+### Decision 3: Section 优先级与 skill 相同
+
+**选择**: schedule section 的 token budget 优先级设为 4（与 skill 相同），token 紧张时优先裁剪。
+
+**理由**: 定时任务能力是辅助性功能，不影响核心的代码操作和对话能力。base/language/task/environment 优先级更高。
+
+### Decision 4: 数据来源 — PromptBuildContext 扩展
+
+**选择**: 在 `PromptBuildContext` 类型中新增可选字段 `scheduleSummary?: string`，由 ChatCapability/WorkflowCapability 在构建 prompt 前查询 ScheduleRepository 并填入。
+
+**替代方案**:
+- A) DynamicPromptBuilder 直接依赖 ScheduleRepository — 拒绝，Builder 是纯 prompt 组装层，不应持有数据依赖
+- B) 通过 AgentContext 间接获取 — 可行但耦合度与方案 A 相同
+
+**理由**: 保持 DynamicPromptBuilder 的纯粹性（只负责组装，不负责数据获取）。数据查询的职责放在 ChatCapability（它已经有 AgentContext 的访问权限）。
+
+## Risks / Trade-offs
+
+- **[Token 消耗增加]** → schedule section 每次对话都会注入，增加约 200-500 tokens。通过 budget 优先级 4 控制上限，token 紧张时自动裁剪。
+- **[任务摘要延迟]** → 每次 chat 都查询 SQLite 获取任务列表。schedules 表通常不超过 50 条，查询延迟可忽略（<1ms）。
+- **[Agent 过度建议]** → LLM 可能在不恰当的时机建议创建定时任务。通过 prompt 中明确的触发条件描述（"when the user expresses recurring needs"）降低误触发率。

--- a/openspec/changes/archive/2026-04-01-schedule-awareness/proposal.md
+++ b/openspec/changes/archive/2026-04-01-schedule-awareness/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Agent 拥有 ScheduleCapability（创建/管理定时任务），但 LLM 在对话中完全不知道这个能力的存在。System prompt（intelligent.md）只声明了 Direct Tools 和 Sub-Agents，未提及定时任务。导致用户表达周期性需求时，Agent 无法主动建议创建定时任务，也无法查询/管理已有任务。
+
+## What Changes
+
+- 新增 `schedule-awareness.md` prompt 模板，声明 Agent 的定时任务能力（创建、查询、暂停、恢复、删除）
+- 在 `DynamicPromptBuilder.buildSections()` 中新增 `schedule` section，将模板注入 system prompt
+- 在注入时附带当前已有的定时任务摘要（让 Agent 感知到已有任务的存在）
+
+## Non-goals
+
+- 不将定时任务注册为 Tool（函数调用），避免污染 ToolRegistry
+- 不修改 ScheduleCapability 的内部实现（4 层防幻觉机制保持不变）
+- 不修改 ScheduleEngine 的调度逻辑
+- 不改变定时任务的触发方式（仍然通过自然语言关键词匹配触发）
+
+## Capabilities
+
+### New Capabilities
+
+_(无新增能力)_
+
+### Modified Capabilities
+
+- `schedule-management`: Agent 在对话中可感知并操作定时任务，而非仅靠隐式的关键词匹配
+
+## Impact
+
+- **packages/core**: `DynamicPromptBuilder` 新增 schedule section 构建逻辑；`AgentContext` 或 `ChatCapability` 需提供已有任务摘要数据
+- **packages/core**: 新增 `templates/schedule-awareness.md` 模板文件
+- **API**: 无变化，纯 prompt 层面改动

--- a/openspec/changes/archive/2026-04-01-schedule-awareness/specs/schedule-management/spec.md
+++ b/openspec/changes/archive/2026-04-01-schedule-awareness/specs/schedule-management/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: ScheduleCapability 作为 Agent 能力注册
+ScheduleCapability SHALL 作为 Agent 的标准能力模块，遵循 Capability 委托模式。
+
+#### Scenario: Capability 初始化
+- **WHEN** Agent 初始化时启用 ScheduleCapability
+- **THEN** Capability SHALL 接收 AgentContext 和 ScheduleRepository 依赖
+- **THEN** Capability SHALL 可通过 `agent.getCapability('schedule')` 访问
+
+#### Scenario: Agent 在对话中感知定时任务能力
+- **WHEN** DynamicPromptBuilder 构建 system prompt 时
+- **THEN** Builder SHALL 加载 `schedule-awareness` 模板作为独立 section
+- **THEN** 模板 SHALL 声明 Agent 具备创建、查询、暂停、恢复、删除定时任务的能力
+- **THEN** 模板 SHALL 说明三种调度模式（cron / every / at）的适用场景
+- **THEN** 模板 SHALL 提示 Agent 在用户表达周期性需求时主动建议创建定时任务
+
+#### Scenario: Agent 在对话中感知已有定时任务
+- **WHEN** ChatCapability 构建 PromptBuildContext 时
+- **THEN** ChatCapability SHALL 查询 ScheduleRepository 获取当前已有任务列表
+- **THEN** ChatCapability SHALL 将任务列表格式化为摘要（名称 + 调度模式 + 状态）
+- **THEN** ChatCapability SHALL 将摘要填入 `PromptBuildContext.scheduleSummary`
+- **THEN** DynamicPromptBuilder SHALL 将 scheduleSummary 嵌入 schedule section
+
+#### Scenario: 无已有定时任务
+- **WHEN** ScheduleRepository 返回空列表
+- **THEN** scheduleSummary SHALL 为空字符串或包含"当前无定时任务"的提示
+- **THEN** schedule section SHALL 仍然注入能力声明，只是不包含任务列表
+
+#### Scenario: Token budget 不足时裁剪 schedule section
+- **WHEN** system prompt 总长度超过 maxChars 预算
+- **THEN** schedule section SHALL 按 priority 4 被裁剪（与 skill section 同级）
+- **THEN** base/language/task/environment section SHALL 不受影响

--- a/openspec/changes/archive/2026-04-01-schedule-awareness/tasks.md
+++ b/openspec/changes/archive/2026-04-01-schedule-awareness/tasks.md
@@ -1,0 +1,18 @@
+## 1. Prompt 模板
+
+- [x] 1.1 创建 `templates/schedule-awareness.md` — 声明定时任务能力（创建/查询/暂停/恢复/删除）、三种调度模式、触发条件、确认流程
+- [x] 1.2 在 DynamicPromptBuilder 中新增 `schedule` section 构建逻辑，加载 schedule-awareness 模板 + 嵌入 scheduleSummary
+- [x] 1.3 设置 schedule section 的 token budget 优先级为 4（与 skill 同级）
+
+## 2. 数据注入
+
+- [x] 2.1 在 `PromptBuildContext` 类型中新增可选字段 `scheduleSummary?: string`
+- [x] 2.2 在 ChatCapability 构建 PromptBuildContext 时查询 ScheduleRepository，格式化已有任务摘要并填入 scheduleSummary
+- [x] 2.3 在 WorkflowCapability 的 buildSystemPrompt 中同样注入 scheduleSummary
+
+## 3. 测试
+
+- [x] 3.1 单元测试：DynamicPromptBuilder 在有 scheduleSummary 时正确注入 schedule section
+- [x] 3.2 单元测试：DynamicPromptBuilder 在无 scheduleSummary 时仍注入能力声明
+- [x] 3.3 单元测试：token budget 不足时 schedule section 被正确裁剪
+- [x] 3.4 单元测试：ChatCapability 构建 context 时正确查询并格式化任务摘要

--- a/openspec/specs/schedule-management/spec.md
+++ b/openspec/specs/schedule-management/spec.md
@@ -48,6 +48,30 @@ ScheduleCapability SHALL 作为 Agent 的标准能力模块，遵循 Capability 
 - **THEN** Capability SHALL 接收 AgentContext 和 ScheduleRepository 依赖
 - **THEN** Capability SHALL 可通过 `agent.getCapability('schedule')` 访问
 
+#### Scenario: Agent 在对话中感知定时任务能力
+- **WHEN** DynamicPromptBuilder 构建 system prompt 时
+- **THEN** Builder SHALL 加载 `schedule-awareness` 模板作为独立 section
+- **THEN** 模板 SHALL 声明 Agent 具备创建、查询、暂停、恢复、删除定时任务的能力
+- **THEN** 模板 SHALL 说明三种调度模式（cron / every / at）的适用场景
+- **THEN** 模板 SHALL 提示 Agent 在用户表达周期性需求时主动建议创建定时任务
+
+#### Scenario: Agent 在对话中感知已有定时任务
+- **WHEN** ChatCapability 构建 PromptBuildContext 时
+- **THEN** ChatCapability SHALL 查询 ScheduleRepository 获取当前已有任务列表
+- **THEN** ChatCapability SHALL 将任务列表格式化为摘要（名称 + 调度模式 + 状态）
+- **THEN** ChatCapability SHALL 将摘要填入 `PromptBuildContext.scheduleSummary`
+- **THEN** DynamicPromptBuilder SHALL 将 scheduleSummary 嵌入 schedule section
+
+#### Scenario: 无已有定时任务
+- **WHEN** ScheduleRepository 返回空列表
+- **THEN** scheduleSummary SHALL 为空字符串或包含"当前无定时任务"的提示
+- **THEN** schedule section SHALL 仍然注入能力声明，只是不包含任务列表
+
+#### Scenario: Token budget 不足时裁剪 schedule section
+- **WHEN** system prompt 总长度超过 maxChars 预算
+- **THEN** schedule section SHALL 按 priority 4 被裁剪（与 skill section 同级）
+- **THEN** base/language/task/environment section SHALL 不受影响
+
 ## ADDED Requirements
 
 ### Requirement: Agent 自主创建定时任务（关键词预过滤）

--- a/packages/core/src/agents/capabilities/ChatCapability.ts
+++ b/packages/core/src/agents/capabilities/ChatCapability.ts
@@ -17,6 +17,7 @@ import { LLMRuntime } from '../runtime/LLMRuntime.js';
 import type { RuntimeConfig } from '../runtime/types.js';
 import { createDynamicPromptBuilder } from '../pipeline/DynamicPromptBuilder.js';
 import type { PromptBuildContext } from '../types/pipeline.js';
+import { buildScheduleSummary } from './schedule-summary.js';
 
 /**
  * 对话能力实现
@@ -105,7 +106,7 @@ export class ChatCapability implements AgentCapability {
     // AI SDK 不允许同时传 prompt 和 messages，有历史时追加当前消息到 messages
     const history = options?.messages;
 
-    // Build system prompt: append environment context to existing systemPrompt
+    // Build system prompt: append environment context and schedule awareness to existing systemPrompt
     let systemPrompt = options?.systemPrompt;
     if (this.context.environmentContext) {
       const builder = createDynamicPromptBuilder();
@@ -122,6 +123,19 @@ export class ChatCapability implements AgentCapability {
       } else {
         systemPrompt = envOnly;
       }
+    }
+
+    // Inject schedule awareness (independent of environmentContext)
+    const scheduleSummary = await buildScheduleSummary(this.context);
+    if (scheduleSummary) {
+      const builder = createDynamicPromptBuilder();
+      const scheduleOnly = builder.buildPrompt({
+        task: '',
+        priorResults: [],
+        agentType: 'general',
+        scheduleSummary,
+      } satisfies PromptBuildContext);
+      systemPrompt = (systemPrompt ? systemPrompt + '\n\n' : '') + scheduleOnly;
     }
 
     const runtimeConfig: RuntimeConfig = {

--- a/packages/core/src/agents/capabilities/WorkflowCapability.ts
+++ b/packages/core/src/agents/capabilities/WorkflowCapability.ts
@@ -26,6 +26,7 @@ import type { Tool } from 'ai';
 import { LLMRuntime } from '../runtime/LLMRuntime.js';
 import { PromptTemplate } from '../prompts/PromptTemplate.js';
 import { createAllSubagentTools } from '../../tools/built-in/subagent-tools.js';
+import { buildScheduleSummary } from './schedule-summary.js';
 
 /**
  * 工作流能力实现
@@ -163,7 +164,7 @@ export class WorkflowCapability implements AgentCapability {
         await this.emitPhase(sessionId, 'execute', '执行任务...', previousPhase, options);
 
         // 构建 system prompt
-        const systemPrompt = this.buildSystemPrompt(task);
+        const systemPrompt = await this.buildSystemPrompt(task);
 
         // 获取全部工具 + 子 Agent 工具
         const tools = {
@@ -253,7 +254,7 @@ export class WorkflowCapability implements AgentCapability {
   /**
    * 构建 system prompt
    */
-  private buildSystemPrompt(task: string): string {
+  private async buildSystemPrompt(task: string): Promise<string> {
     const isChineseTask = /[\u4e00-\u9fa5]/.test(task);
     const languageInstruction = isChineseTask
       ? '【重要】你必须用中文回复，与用户的语言保持一致。'
@@ -268,10 +269,20 @@ export class WorkflowCapability implements AgentCapability {
       skillSection = this.context.skillRegistry.generateSkillListDescription();
     }
 
-    return this.promptTemplate.render('intelligent', {
+    let prompt = this.promptTemplate.render('intelligent', {
       languageInstruction,
       skillSection: skillSection ?? '',
       task,
     });
+
+    // Append schedule awareness section
+    const scheduleSummary = await buildScheduleSummary(this.context);
+    if (scheduleSummary) {
+      prompt += '\n\n' + this.promptTemplate.render('schedule-awareness', {
+        scheduleSummary,
+      });
+    }
+
+    return prompt;
   }
 }

--- a/packages/core/src/agents/capabilities/schedule-summary.ts
+++ b/packages/core/src/agents/capabilities/schedule-summary.ts
@@ -1,0 +1,41 @@
+/**
+ * Schedule summary builder
+ *
+ * Shared utility for building schedule awareness summaries in system prompts.
+ * Used by ChatCapability and WorkflowCapability.
+ */
+
+import type { AgentContext } from '../core/types.js';
+import type { IScheduleRepository } from '../../scheduler/types.js';
+
+/**
+ * Build a formatted summary of existing scheduled tasks.
+ * Returns empty string if schedule capability is not available or query fails.
+ */
+export async function buildScheduleSummary(context: AgentContext): Promise<string> {
+  try {
+    const scheduleCap = context.getCapability<import('./ScheduleCapability.js').ScheduleCapability>('schedule');
+    if (!scheduleCap?.getRepository) return '';
+
+    const repo = scheduleCap.getRepository();
+    const schedules = await repo.findAll();
+
+    if (schedules.length === 0) {
+      return '\n### Current Scheduled Tasks\n\nNo scheduled tasks configured.';
+    }
+
+    const lines = schedules.map(s => {
+      const status = s.enabled ? 'enabled' : 'paused';
+      const schedule = s.scheduleKind === 'cron'
+        ? `cron: ${s.cron}`
+        : s.scheduleKind === 'every'
+          ? `every ${Math.round((s.intervalMs ?? 0) / 1000)}s`
+          : `at: ${s.runAt}`;
+      return `- **${s.name}** (${s.scheduleKind}, ${status}, ${schedule})`;
+    });
+
+    return `\n### Current Scheduled Tasks\n\n${lines.join('\n')}`;
+  } catch {
+    return '';
+  }
+}

--- a/packages/core/src/agents/pipeline/DynamicPromptBuilder.ts
+++ b/packages/core/src/agents/pipeline/DynamicPromptBuilder.ts
@@ -89,6 +89,14 @@ export class DynamicPromptBuilder {
       sections.set('skill', context.skillSection);
     }
 
+    // 6. Schedule awareness section
+    if (context.scheduleSummary !== undefined) {
+      const scheduleSection = this.formatScheduleSection(context.scheduleSummary);
+      if (scheduleSection) {
+        sections.set('schedule', scheduleSection);
+      }
+    }
+
     return sections;
   }
 
@@ -168,6 +176,18 @@ export class DynamicPromptBuilder {
   }
 
   /**
+   * Format schedule awareness section
+   */
+  private formatScheduleSection(scheduleSummary: string): string {
+    try {
+      const template = this.promptTemplate.load('schedule-awareness');
+      return template.replaceAll('{{scheduleSummary}}', scheduleSummary);
+    } catch {
+      return '';
+    }
+  }
+
+  /**
    * Format session history into a prompt section
    */
   private formatSessionHistory(messages: Array<{ role: string; content: string }>): string {
@@ -193,6 +213,7 @@ export class DynamicPromptBuilder {
       history: 1,       // Session history - important for context continuity
       context: 2,       // High priority but can be truncated
       skill: 4,         // Lower priority, can be removed
+      schedule: 4,      // Same as skill, can be removed
     };
 
     // Calculate total size
@@ -240,7 +261,7 @@ export class DynamicPromptBuilder {
    * Join sections into final prompt
    */
   private joinSections(sections: Map<string, string>): string {
-    const order = ['base', 'language', 'task', 'environment', 'history', 'context', 'skill'];
+    const order = ['base', 'language', 'task', 'environment', 'history', 'context', 'skill', 'schedule'];
     const parts: string[] = [];
 
     for (const name of order) {

--- a/packages/core/src/agents/prompts/templates/schedule-awareness.md
+++ b/packages/core/src/agents/prompts/templates/schedule-awareness.md
@@ -1,0 +1,30 @@
+## Scheduled Tasks
+
+You can create and manage scheduled tasks on behalf of the user. This allows the user to automate recurring work.
+
+### When to Suggest
+Proactively suggest creating a scheduled task when the user expresses:
+- Recurring needs (e.g., "every morning", "weekly", "periodically")
+- Monitoring requests (e.g., "keep an eye on", "watch for changes")
+- Reminder or notification requests
+- Any repetitive task that could be automated
+
+### Schedule Modes
+- **cron**: Standard cron expressions for periodic execution (e.g., `0 9 * * *` = every day at 9:00 AM, `0 9 * * 1` = every Monday at 9:00 AM)
+- **every**: Fixed interval in natural language (e.g., "every 30 minutes", "every 2 hours"). Minimum interval is 1 minute.
+- **at**: One-time execution at a specific datetime (e.g., "tomorrow at 3 PM", "2026-04-01 15:00")
+
+### Confirmation Required
+Always confirm with the user before creating a scheduled task. Present:
+- Task name
+- Schedule mode and parameters
+- What the task will do (the execution prompt)
+
+### Task Management
+You can also help the user with:
+- Listing existing scheduled tasks and their status
+- Pausing or resuming tasks
+- Modifying task configuration
+- Deleting tasks
+
+{{scheduleSummary}}

--- a/packages/core/src/agents/types/pipeline.ts
+++ b/packages/core/src/agents/types/pipeline.ts
@@ -79,4 +79,6 @@ export interface PromptBuildContext {
   sessionHistory?: Array<{ role: string; content: string }>;
   /** 系统环境信息（可选，注入到 system prompt 中） */
   environmentContext?: EnvironmentContext;
+  /** 定时任务摘要（可选，注入到 schedule awareness section） */
+  scheduleSummary?: string;
 }

--- a/packages/core/tests/unit/dynamic-prompt-builder.test.ts
+++ b/packages/core/tests/unit/dynamic-prompt-builder.test.ts
@@ -310,4 +310,60 @@ describe('DynamicPromptBuilder', () => {
       expect(prompt).toContain('Linux (linux/x64)');
     });
   });
+
+  describe('schedule awareness section', () => {
+    it('should include schedule section when scheduleSummary is provided', () => {
+      const context: PromptBuildContext = {
+        task: 'Check my tasks',
+        priorResults: [],
+        agentType: 'general',
+        scheduleSummary: '\n### Current Scheduled Tasks\n\n- **Daily logs** (cron, enabled, cron: 0 9 * * *)',
+      };
+
+      const prompt = builder.buildPrompt(context);
+      expect(prompt).toContain('## Scheduled Tasks');
+      expect(prompt).toContain('Daily logs');
+      expect(prompt).toContain('0 9 * * *');
+    });
+
+    it('should include schedule capability declaration even without tasks', () => {
+      const context: PromptBuildContext = {
+        task: 'Hello',
+        priorResults: [],
+        agentType: 'general',
+        scheduleSummary: '\n### Current Scheduled Tasks\n\nNo scheduled tasks configured.',
+      };
+
+      const prompt = builder.buildPrompt(context);
+      expect(prompt).toContain('## Scheduled Tasks');
+      expect(prompt).toContain('No scheduled tasks configured');
+      expect(prompt).toContain('Confirmation Required');
+    });
+
+    it('should not include schedule section when scheduleSummary is undefined', () => {
+      const context: PromptBuildContext = {
+        task: 'Hello',
+        priorResults: [],
+        agentType: 'general',
+      };
+
+      const prompt = builder.buildPrompt(context);
+      expect(prompt).not.toContain('## Scheduled Tasks');
+    });
+
+    it('should truncate schedule section when over budget (priority 4)', () => {
+      const smallBuilder = new DynamicPromptBuilder({ maxChars: 100 });
+
+      const context: PromptBuildContext = {
+        task: 'Test task',
+        priorResults: [],
+        agentType: 'general',
+        scheduleSummary: '\n### Current Scheduled Tasks\n\n' + '- **Task** (cron, enabled, cron: 0 9 * * *)\n'.repeat(50),
+      };
+
+      const prompt = smallBuilder.buildPrompt(context);
+      // Task should still be present
+      expect(prompt).toContain('Test task');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- 新增 `schedule-awareness.md` prompt 模板，让 LLM 知道 Agent 可以创建/管理定时任务
- DynamicPromptBuilder 新增 schedule section（token budget priority 4，与 skill 同级）
- ChatCapability / WorkflowCapability 查询 ScheduleRepository 注入已有任务摘要
- 提取共享 `schedule-summary.ts` 工具函数消除代码重复
- 修复 code review 发现的 `intervalMs!` 非空断言和 `replace` → `replaceAll`

## Test plan
- [x] pnpm test 通过（66 文件，1132 用例，+4 新增）
- [x] 构建 tsc 编译通过
- [ ] 对话中验证 Agent 能感知定时任务能力（需手动测试）

Closes #72