### PR TITLE
fix: hive plugin update 无法覆盖已安装插件

### DIFF
--- a/apps/server/src/plugin-manager/installer.ts
+++ b/apps/server/src/plugin-manager/installer.ts
@@ -69,7 +69,7 @@ export function resolveSource(input: string): PluginSource {
 /**
  * 安装插件（统一入口）
  */
-export async function installPlugin(input: string): Promise<InstallResult> {
+export async function installPlugin(input: string, options?: { force?: boolean }): Promise<InstallResult> {
   const source = resolveSource(input)
 
   // 路径穿越检查
@@ -79,14 +79,21 @@ export async function installPlugin(input: string): Promise<InstallResult> {
 
   const targetDir = resolve(PLUGINS_DIR, source.targetName)
 
-  // 检查是否已安装
-  const { hasPlugin } = await import('./registry.js')
-  if (hasPlugin(source.targetName)) {
-    return {
-      success: false,
-      name: source.targetName,
-      error: 'Plugin already installed. Use `hive plugin update <name>` to upgrade.',
+  // 检查是否已安装（force 模式跳过检查）
+  if (!options?.force) {
+    const { hasPlugin } = await import('./registry.js')
+    if (hasPlugin(source.targetName)) {
+      return {
+        success: false,
+        name: source.targetName,
+        error: 'Plugin already installed. Use `hive plugin update <name>` to upgrade.',
+      }
     }
+  }
+
+  // force 模式：先清理旧文件
+  if (options?.force && existsSync(targetDir)) {
+    cleanupDir(targetDir)
   }
 
   try {

--- a/apps/server/src/plugin-manager/manager.ts
+++ b/apps/server/src/plugin-manager/manager.ts
@@ -162,9 +162,18 @@ export async function updatePlugin(name?: string): Promise<{ updated: string[]; 
 
       console.log(`  Updating ${pluginName}: ${entry.resolvedVersion} → ${latest.version}`)
 
+      // 备份用户配置
+      const configBackup = backupPluginConfig(pluginName)
+
+      // 先从注册表移除旧记录
+      removePlugin(pluginName)
+
+      // 强制重新安装
       const { installPlugin } = await import('./installer.js')
-      const result = await installPlugin(`${npmPackage}@${latest.version}`)
+      const result = await installPlugin(`${npmPackage}@${latest.version}`, { force: true })
       if (result.success) {
+        // 恢复用户配置
+        restorePluginConfig(pluginName, configBackup)
         updated.push(pluginName)
       } else {
         errors.push({ name: pluginName, error: result.error || 'Install failed' })
@@ -203,5 +212,30 @@ function readPluginConfig(): Record<string, Record<string, unknown>> {
   } catch {
     console.warn('[plugin-manager] Failed to read hive.config.json')
     return {}
+  }
+}
+
+/**
+ * 备份插件配置（返回配置快照，更新失败时可恢复）
+ */
+function backupPluginConfig(pluginName: string): Record<string, unknown> | null {
+  const configs = readPluginConfig()
+  return configs[pluginName] ?? null
+}
+
+/**
+ * 恢复插件配置（更新后写入用户之前的配置）
+ */
+function restorePluginConfig(pluginName: string, config: Record<string, unknown> | null): void {
+  if (!config || !existsSync(CONFIG_PATH)) return
+
+  try {
+    const content = readFileSync(CONFIG_PATH, 'utf-8')
+    const hiveConfig = JSON.parse(content)
+    if (!hiveConfig.plugins) hiveConfig.plugins = {}
+    hiveConfig.plugins[pluginName] = config
+    atomicWriteJSON(CONFIG_PATH, hiveConfig)
+  } catch {
+    console.warn('[plugin-manager] Failed to restore plugin config')
   }
 }


### PR DESCRIPTION
## Summary
- `installPlugin` 增加 `{ force }` 选项，允许覆盖安装
- `updatePlugin` 流程改为：备份配置 → 移除注册表 → 强制重装 → 恢复配置
- 修复 `hive plugin update` 永远返回 "Plugin already installed" 的问题

## Test plan
- [ ] `hive plugin update feishu` 成功更新到最新版本
- [ ] 更新后 `hive.config.json` 中用户配置不丢失
- [ ] server 启动后插件正常加载，无 `messageBus` 错误
- [ ] `pnpm --filter @bundy-lmw/hive-server build` 编译通过

Closes #106