### PR TITLE
style: 优化 README Logo 排版对齐问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>
-    <img src="logo.svg" alt="Hive Logo" width="80" height="80" style="vertical-align: middle;"> <span style="font-size: 2em; font-weight: bold; vertical-align: middle;">Hive</span>
+    <img src="logo-with-text.svg" alt="Hive" width="160">
   </p>
 
   <p><strong>The Multi-Agent SDK for TypeScript</strong></p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>
-    <img src="logo.svg" alt="Hive Logo" width="80" height="80" style="vertical-align: middle;"> <span style="font-size: 2em; font-weight: bold; vertical-align: middle;">Hive</span>
+    <img src="logo-with-text.svg" alt="Hive" width="160">
   </p>
 
   <p><strong>TypeScript 多 Agent 编排 SDK</strong></p>

--- a/logo-with-text.svg
+++ b/logo-with-text.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 80">
+  <defs>
+    <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fbbf24"/>
+      <stop offset="100%" stop-color="#d97706"/>
+    </linearGradient>
+  </defs>
+  <!-- Hexagon -->
+  <polygon points="40,4 72,22 72,58 40,76 8,58 8,22" fill="url(#hg)"/>
+  <text x="40" y="53" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-weight="700" font-size="38" fill="#0a0a0a">H</text>
+  <!-- Brand name -->
+  <text x="88" y="53" font-family="Inter,system-ui,sans-serif" font-weight="700" font-size="38" fill="#1a1a1a">Hive</text>
+</svg>


### PR DESCRIPTION
## Summary
- 创建合并 SVG（`logo-with-text.svg`），将蜂巢六边形 Logo + "Hive" 文字合为一张图
- 对齐在 SVG 内部精确控制，不依赖 GitHub CSS 渲染
- 更新 `README.md` 和 `README.zh-CN.md` 引用新 Logo

## Test plan
- [x] pnpm test 通过（166 passed）
- [ ] GitHub 上预览 Logo 与文字对齐正常

Closes #109