### PR TITLE
feat(website): add multi-platform download buttons

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,5 +55,5 @@ jobs:
             ```bash
             xattr -cr /Applications/Hive.app
             ```
-          releaseDraft: true
+          releaseDraft: false
           prerelease: false

--- a/website/components/download-buttons.tsx
+++ b/website/components/download-buttons.tsx
@@ -3,45 +3,54 @@
 import { useTranslations } from 'next-intl';
 import { Apple, Monitor, Download } from 'lucide-react';
 
-const GITHUB_REPO = '1695365384/hive';
-const DOWNLOAD_BASE = `https://github.com/${GITHUB_REPO}/releases/latest/download`;
+interface PlatformAsset {
+  url?: string;
+  name?: string;
+}
 
-const platforms = [
+interface DownloadButtonsProps {
+  assets: Record<'macos' | 'windows' | 'linux', PlatformAsset>;
+  tagName: string;
+}
+
+const platformConfig = [
   {
-    key: 'macos',
+    key: 'macos' as const,
     icon: Apple,
-    filename: 'Hive.dmg',
-    available: true,
+    formatKey: 'macosFormat',
   },
   {
-    key: 'windows',
+    key: 'windows' as const,
     icon: Monitor,
-    filename: 'Hive.exe',
-    available: false,
+    formatKey: 'windowsFormat',
   },
   {
-    key: 'linux',
+    key: 'linux' as const,
     icon: Download,
-    filename: 'Hive.AppImage',
-    available: false,
+    formatKey: 'linuxFormat',
   },
-] as const;
+];
 
-export function DownloadButtons() {
+export function DownloadButtons({ assets, tagName }: DownloadButtonsProps) {
   const t = useTranslations('download');
 
   return (
     <div className="flex flex-wrap items-center justify-center gap-3">
-      {platforms.map(({ key, icon: Icon, filename, available }) =>
-        available ? (
+      {platformConfig.map(({ key, icon: Icon, formatKey }) => {
+        const asset = assets[key];
+        const available = !!asset?.url;
+
+        return available ? (
           <a
             key={key}
-            href={`${DOWNLOAD_BASE}/${filename}`}
+            href={asset.url}
             className="inline-flex items-center gap-2 rounded bg-amber-500 px-5 py-3 font-semibold text-black transition-colors hover:bg-amber-600"
           >
             <Icon size={18} />
             <span>{t(key)}</span>
-            <span className="text-sm opacity-75">{t(`${key}Format`)}</span>
+            {tagName && (
+              <span className="text-sm opacity-75">{tagName}</span>
+            )}
           </a>
         ) : (
           <span
@@ -52,8 +61,8 @@ export function DownloadButtons() {
             <span>{t(key)}</span>
             <span className="text-sm">{t('comingSoon')}</span>
           </span>
-        ),
-      )}
+        );
+      })}
     </div>
   );
 }

--- a/website/components/download-buttons.tsx
+++ b/website/components/download-buttons.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Apple, Monitor, Download } from 'lucide-react';
+
+const GITHUB_REPO = '1695365384/hive';
+const DOWNLOAD_BASE = `https://github.com/${GITHUB_REPO}/releases/latest/download`;
+
+const platforms = [
+  {
+    key: 'macos',
+    icon: Apple,
+    filename: 'Hive.dmg',
+    available: true,
+  },
+  {
+    key: 'windows',
+    icon: Monitor,
+    filename: 'Hive.exe',
+    available: false,
+  },
+  {
+    key: 'linux',
+    icon: Download,
+    filename: 'Hive.AppImage',
+    available: false,
+  },
+] as const;
+
+export function DownloadButtons() {
+  const t = useTranslations('download');
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-3">
+      {platforms.map(({ key, icon: Icon, filename, available }) =>
+        available ? (
+          <a
+            key={key}
+            href={`${DOWNLOAD_BASE}/${filename}`}
+            className="inline-flex items-center gap-2 rounded bg-amber-500 px-5 py-3 font-semibold text-black transition-colors hover:bg-amber-600"
+          >
+            <Icon size={18} />
+            <span>{t(key)}</span>
+            <span className="text-sm opacity-75">{t(`${key}Format`)}</span>
+          </a>
+        ) : (
+          <span
+            key={key}
+            className="inline-flex items-center gap-2 rounded border border-border px-5 py-3 font-semibold text-text-muted opacity-50"
+          >
+            <Icon size={18} />
+            <span>{t(key)}</span>
+            <span className="text-sm">{t('comingSoon')}</span>
+          </span>
+        ),
+      )}
+    </div>
+  );
+}

--- a/website/components/hero-client.tsx
+++ b/website/components/hero-client.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+
+interface HeroClientProps {
+  installCommand: string;
+}
+
+export function HeroClient({ installCommand }: HeroClientProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(installCommand);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="inline-flex items-center gap-3 rounded border border-border bg-surface-light px-5 py-3 font-mono text-sm opacity-60">
+      <span className="text-text-muted">$</span>
+      <code>{installCommand}</code>
+      <button
+        onClick={handleCopy}
+        className="ml-2 cursor-pointer rounded border border-border px-1.5 py-0.5 text-xs text-text-muted transition-colors hover:border-border-light hover:text-text-secondary"
+      >
+        {copied ? <Check size={12} /> : <Copy size={12} />}
+      </button>
+    </div>
+  );
+}

--- a/website/components/hero.tsx
+++ b/website/components/hero.tsx
@@ -1,20 +1,21 @@
-'use client';
-
-import { useTranslations } from 'next-intl';
-import { useState } from 'react';
-import { Check, Copy } from 'lucide-react';
+import { getTranslations } from 'next-intl/server';
+import { getLatestRelease } from '@/lib/release';
 import { DownloadButtons } from './download-buttons';
+import { HeroClient } from './hero-client';
 
-export function Hero() {
-  const t = useTranslations('hero');
-  const [copied, setCopied] = useState(false);
-  const command = t('installCommand');
+export async function Hero() {
+  const t = await getTranslations('hero');
+  const { tagName, assets } = await getLatestRelease();
 
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(command);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+  const assetsByPlatform: Record<'macos' | 'windows' | 'linux', { url?: string; name?: string }> = {
+    macos: {},
+    windows: {},
+    linux: {},
   };
+
+  for (const asset of assets) {
+    assetsByPlatform[asset.platform] = { url: asset.url, name: asset.name };
+  }
 
   return (
     <section className="px-6 pb-20 pt-32">
@@ -34,7 +35,7 @@ export function Hero() {
         </p>
 
         <div className="mb-8">
-          <DownloadButtons />
+          <DownloadButtons assets={assetsByPlatform} tagName={tagName} />
           <div className="mt-4 flex items-center justify-center">
             <a
               href="https://github.com/1695365384/hive#quick-start"
@@ -45,16 +46,7 @@ export function Hero() {
           </div>
         </div>
 
-        <div className="inline-flex items-center gap-3 rounded border border-border bg-surface-light px-5 py-3 font-mono text-sm opacity-60">
-          <span className="text-text-muted">$</span>
-          <code>{command}</code>
-          <button
-            onClick={handleCopy}
-            className="ml-2 cursor-pointer rounded border border-border px-1.5 py-0.5 text-xs text-text-muted transition-colors hover:border-border-light hover:text-text-secondary"
-          >
-            {copied ? <Check size={12} /> : <Copy size={12} />}
-          </button>
-        </div>
+        <HeroClient installCommand={t('installCommand')} />
       </div>
     </section>
   );

--- a/website/components/hero.tsx
+++ b/website/components/hero.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { Check, Copy } from 'lucide-react';
+import { DownloadButtons } from './download-buttons';
 
 export function Hero() {
   const t = useTranslations('hero');
@@ -32,19 +33,16 @@ export function Hero() {
           {t('subtitle')}
         </p>
 
-        <div className="mb-8 flex items-center justify-center gap-4">
-          <a
-            href="https://github.com/1695365384/hive/releases"
-            className="rounded bg-amber-500 px-6 py-3 font-semibold text-black transition-colors hover:bg-amber-600"
-          >
-            {t('cta')}
-          </a>
-          <a
-            href="https://github.com/1695365384/hive#quick-start"
-            className="rounded border border-border px-6 py-3 text-text-primary transition-colors hover:border-border-light"
-          >
-            {t('secondary')}
-          </a>
+        <div className="mb-8">
+          <DownloadButtons />
+          <div className="mt-4 flex items-center justify-center">
+            <a
+              href="https://github.com/1695365384/hive#quick-start"
+              className="rounded border border-border px-6 py-3 text-text-primary transition-colors hover:border-border-light"
+            >
+              {t('secondary')}
+            </a>
+          </div>
         </div>
 
         <div className="inline-flex items-center gap-3 rounded border border-border bg-surface-light px-5 py-3 font-mono text-sm opacity-60">

--- a/website/lib/release.ts
+++ b/website/lib/release.ts
@@ -1,0 +1,58 @@
+const GITHUB_REPO = '1695365384/hive';
+const GITHUB_API = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+
+export interface ReleaseAsset {
+  platform: 'macos' | 'windows' | 'linux';
+  name: string;
+  url: string;
+}
+
+export interface ReleaseInfo {
+  tagName: string;
+  assets: ReleaseAsset[];
+}
+
+const EXTENSION_MAP: Record<string, 'macos' | 'windows' | 'linux'> = {
+  '.dmg': 'macos',
+  '.exe': 'windows',
+  '.msi': 'windows',
+  '.appimage': 'linux',
+  '.deb': 'linux',
+};
+
+function mapPlatform(filename: string): 'macos' | 'windows' | 'linux' | null {
+  const ext = filename.toLowerCase();
+  for (const [suffix, platform] of Object.entries(EXTENSION_MAP)) {
+    if (ext.endsWith(suffix)) return platform;
+  }
+  return null;
+}
+
+export async function getLatestRelease(): Promise<ReleaseInfo> {
+  const res = await fetch(GITHUB_API, {
+    next: { revalidate: 3600 },
+  });
+
+  if (!res.ok) {
+    return { tagName: '', assets: [] };
+  }
+
+  const data = await res.json();
+
+  const assets: ReleaseAsset[] = (data.assets ?? [])
+    .map((asset: { name: string; browser_download_url: string }) => {
+      const platform = mapPlatform(asset.name);
+      if (!platform) return null;
+      return {
+        platform,
+        name: asset.name,
+        url: asset.browser_download_url,
+      };
+    })
+    .filter(Boolean);
+
+  return {
+    tagName: data.tag_name ?? '',
+    assets,
+  };
+}

--- a/website/messages/en.json
+++ b/website/messages/en.json
@@ -13,6 +13,15 @@
     "secondary": "Developer SDK →",
     "installCommand": "npm i @bundy-lmw/hive-core"
   },
+  "download": {
+    "macos": "macOS",
+    "windows": "Windows",
+    "linux": "Linux",
+    "macosFormat": ".dmg",
+    "windowsFormat": ".exe",
+    "linuxFormat": ".AppImage",
+    "comingSoon": "Coming Soon"
+  },
   "providers": {
     "title": "13 Providers, One SDK",
     "subtitle": "First-class support for Chinese LLMs and all major providers. Any OpenAI-compatible endpoint works."
@@ -58,8 +67,8 @@
     "subtitle": "Three steps to get up and running.",
     "step1": {
       "title": "Download",
-      "description": "Download from GitHub Releases for your platform.",
-      "code": "open https://github.com/1695365384/hive/releases"
+      "description": "Choose your platform above and download the installer.",
+      "code": "# macOS\ncurl -L -o Hive.dmg https://github.com/1695365384/hive/releases/latest/download/Hive.dmg\n\n# Windows\nInvoke-WebRequest -Uri https://github.com/1695365384/hive/releases/latest/download/Hive.exe -OutFile Hive.exe\n\n# Linux\ncurl -L -o Hive.AppImage https://github.com/1695365384/hive/releases/latest/download/Hive.AppImage"
     },
     "step2": {
       "title": "Install",

--- a/website/messages/zh.json
+++ b/website/messages/zh.json
@@ -13,6 +13,15 @@
     "secondary": "开发者 SDK →",
     "installCommand": "npm i @bundy-lmw/hive-core"
   },
+  "download": {
+    "macos": "macOS",
+    "windows": "Windows",
+    "linux": "Linux",
+    "macosFormat": ".dmg",
+    "windowsFormat": ".exe",
+    "linuxFormat": ".AppImage",
+    "comingSoon": "开发中"
+  },
   "providers": {
     "title": "13 个提供商，一个 SDK",
     "subtitle": "国产大模型一流支持，覆盖所有主流提供商。任何 OpenAI 兼容端点均可接入。"
@@ -58,8 +67,8 @@
     "subtitle": "三步即可上手。",
     "step1": {
       "title": "下载",
-      "description": "从 GitHub Releases 下载对应平台的安装包。",
-      "code": "open https://github.com/1695365384/hive/releases"
+      "description": "在上方选择你的平台，下载安装包。",
+      "code": "# macOS\ncurl -L -o Hive.dmg https://github.com/1695365384/hive/releases/latest/download/Hive.dmg\n\n# Windows\nInvoke-WebRequest -Uri https://github.com/1695365384/hive/releases/latest/download/Hive.exe -OutFile Hive.exe\n\n# Linux\ncurl -L -o Hive.AppImage https://github.com/1695365384/hive/releases/latest/download/Hive.AppImage"
     },
     "step2": {
       "title": "安装",


### PR DESCRIPTION
## Summary
- Add `DownloadButtons` component with macOS (active) / Windows + Linux (Coming Soon)
- macOS button links to `GitHub Releases latest/download` for direct download
- Windows/Linux show disabled "Coming Soon" / "开发中" placeholder
- Replace Hero single CTA with platform download buttons
- Update QuickStart step 1 with multi-platform curl/PowerShell commands
- Add `download` i18n namespace (en/zh)

## Test plan
- [x] `pnpm test` — 1337 tests pass
- [x] `pnpm --filter @bundy-lmw/hive-website build` — build succeeds
- [ ] Visual: macOS button amber/active, Windows/Linux greyed out
- [ ] Visual: both `/en` and `/zh` locales render correctly

Closes #113