### PR TITLE
ci: 修复 release 流程 — 自动上传构建产物 + 版本号同步 + 多平台构建

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,42 @@ permissions:
   contents: write
 
 jobs:
-  build-macos:
-    runs-on: macos-14
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create-release.outputs.result }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create draft release
+        id: create-release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: '${{ github.ref_name }}',
+              name: 'Hive ${{ github.ref_name }}',
+              body: `## Hive ${{ github.ref_name }}\n\n### macOS 安装说明\n\n如果双击安装包提示"已损坏"，请：\n1. 右键点击 Hive.app → 选择"打开"\n2. 在弹出的对话框中点击"打开"\n\n或终端执行：\n\`\`\`bash\nxattr -cr /Applications/Hive.app\n\`\`\``,
+              draft: true,
+              prerelease: false
+            })
+            return data.id
+
+  build:
+    needs: create-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            args: '--target aarch64-apple-darwin'
+          - platform: windows-latest
+            args: ''
+
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - uses: actions/checkout@v4
@@ -23,6 +57,32 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin' || '' }}
+
+      - name: Install system dependencies (ubuntu)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Set version from tag
+        shell: bash
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          # package.json
+          cd apps/desktop
+          node -e "const p=require('./package.json'); p.version='$VERSION'; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n')"
+          # tauri.conf.json
+          node -e "const p=require('./src-tauri/tauri.conf.json'); p.version='$VERSION'; require('fs').writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(p, null, 2) + '\n')"
+          # Cargo.toml
+          node -e "const fs=require('fs'); let c=fs.readFileSync('src-tauri/Cargo.toml','utf8'); c=c.replace(/^version = \".*?\"/m, 'version = \"$VERSION\"'); fs.writeFileSync('src-tauri/Cargo.toml', c)"
+          cd ../..
+
       - run: pnpm install
 
       - name: Build core
@@ -33,27 +93,34 @@ jobs:
 
       - name: Bundle server (SEA)
         run: bash apps/server/scripts/bundle.sh
+        shell: bash
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0.5
+        uses: tauri-apps/tauri-action@v0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           projectPath: apps/desktop
-          tagName: ${{ github.ref_name }}
-          releaseName: 'Hive ${{ github.ref_name }}'
-          releaseBody: |
-            ## Hive ${{ github.ref_name }}
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+          args: ${{ matrix.args }}
 
-            ### macOS 安装说明
+  publish-release:
+    needs: build
+    runs-on: ubuntu-latest
 
-            如果双击安装包提示"已损坏"，请：
-            1. 右键点击 Hive.app → 选择"打开"
-            2. 在弹出的对话框中点击"打开"
-
-            或终端执行：
-            ```bash
-            xattr -cr /Applications/Hive.app
-            ```
-          releaseDraft: false
-          prerelease: false
+    steps:
+      - name: Publish release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: '${{ github.ref_name }}'
+            })
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: data.id,
+              draft: false
+            })

--- a/website/app/[locale]/page.tsx
+++ b/website/app/[locale]/page.tsx
@@ -7,6 +7,8 @@ import { Screenshots } from '@/components/screenshots';
 import { QuickStart } from '@/components/quick-start';
 import { Footer } from '@/components/footer';
 
+export const dynamic = 'force-dynamic';
+
 export default function HomePage() {
   return (
     <>


### PR DESCRIPTION
## Summary
- 重构 `release.yml` 为三阶段流水线（create draft → build matrix → publish），解决构建产物上传丢失问题
- 构建前从 tag 同步版本号到 `package.json`/`tauri.conf.json`/`Cargo.toml`，安装包命名跟随 tag
- 升级 `tauri-action` v0.5 → v0.6，新增 Windows 构建
- website `page.tsx` 添加 `force-dynamic` 确保 release 数据实时获取

## Test plan
- [ ] 推送 `v*` tag 触发 release workflow，验证 draft release 创建成功
- [ ] macOS + Windows 构建完成后产物上传到同一个 release
- [ ] draft release 自动发布，assets 包含 `.dmg` 和 `.msi`
- [ ] 安装包命名包含正确版本号（如 `Hive_0.3.6_aarch64.dmg`）
- [ ] website 下载按钮正确显示并跳转到正确的下载链接

Closes #119