### PR TITLE
perf: release API 加 Token 认证缩短缓存时间

### DIFF
--- a/website/lib/release.ts
+++ b/website/lib/release.ts
@@ -2,6 +2,7 @@ const GITHUB_REPO = '1695365384/hive';
 const GITHUB_API = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
 
 const DOWNLOAD_PROXY_BASE = process.env.DOWNLOAD_PROXY_BASE; // e.g. https://hive-download-proxy.xxx.workers.dev
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 
 export interface ReleaseAsset {
   platform: 'macos' | 'windows' | 'linux';
@@ -31,8 +32,14 @@ function mapPlatform(filename: string): 'macos' | 'windows' | 'linux' | null {
 }
 
 export async function getLatestRelease(): Promise<ReleaseInfo> {
+  const headers: Record<string, string> = {};
+  if (GITHUB_TOKEN) {
+    headers['Authorization'] = `Bearer ${GITHUB_TOKEN}`;
+  }
+
   const res = await fetch(GITHUB_API, {
-    next: { revalidate: 3600 },
+    headers,
+    next: { revalidate: 300 },
   });
 
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- 加 `GITHUB_TOKEN` 环境变量，API 限流从 60 提升到 5000 次/小时
- ISR `revalidate` 从 3600 缩短到 300（5 分钟），新 release 发布后 5 分钟内更新

## Test plan
- [ ] Vercel 配置 `GITHUB_TOKEN` 环境变量后 website 正常显示版本号和下载按钮
- [ ] 验证 5 分钟缓存生效

Closes #127