### PR TITLE
ci: enable Windows desktop build in release and PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,37 @@ jobs:
 
       - name: Type check desktop
         run: pnpm --filter @bundy-lmw/hive-desktop exec tsc --noEmit
+
+  build-desktop-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '9'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - run: pnpm install
+
+      - name: Build core
+        run: pnpm --filter @bundy-lmw/hive-core build
+
+      - name: Build server
+        run: pnpm --filter @bundy-lmw/hive-server build
+
+      - name: Bundle server (SEA)
+        run: node apps/server/scripts/bundle.mjs
+
+      - name: Build Tauri app (Windows)
+        run: pnpm --filter @bundy-lmw/hive-desktop tauri build
+        env:
+          CI: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
                 repo: context.repo.repo,
                 tag_name: tag,
                 name: `Hive ${tag}`,
-                body: `## Hive ${tag}\n\n### macOS 安装说明\n\n如果双击安装包提示"已损坏"，请：\n1. 右键点击 Hive.app → 选择"打开"\n2. 在弹出的对话框中点击"打开"\n\n或终端执行：\n\`\`\`bash\nxattr -cr /Applications/Hive.app\n\`\`\``,
+                body: `## Hive ${tag}\n\n### macOS 安装说明\n\n如果双击安装包提示"已损坏"，请：\n1. 右键点击 Hive.app → 选择"打开"\n2. 在弹出的对话框中点击"打开"\n\n或终端执行：\n\`\`\`bash\nxattr -cr /Applications/Hive.app\n\`\`\`\n\n### Windows 安装说明\n\n若 SmartScreen 提示未知发布者，点击「更多信息」→「仍要运行」。安装包当前未做代码签名。`,
                 draft: true,
                 prerelease: false
               })
@@ -50,9 +50,8 @@ jobs:
         include:
           - platform: macos-latest
             args: '--target aarch64-apple-darwin'
-          # TODO: Re-enable Windows build after fixing CI compilation issues
-          # - platform: windows-latest
-          #   args: ''
+          - platform: windows-latest
+            args: ''
 
     runs-on: ${{ matrix.platform }}
 
@@ -106,8 +105,7 @@ jobs:
         run: pnpm --filter @bundy-lmw/hive-server build
 
       - name: Bundle server (SEA)
-        run: bash apps/server/scripts/bundle.sh
-        shell: bash
+        run: node apps/server/scripts/bundle.mjs
 
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0.6


### PR DESCRIPTION
## Summary
- Release workflow 启用 windows-latest 打包
- server sidecar 改用跨平台 bundle.mjs
- CI 增加 Windows Tauri build 验证 job

## Test plan
- [ ] 合并后观察 CI build-desktop-windows job
- [ ] 打 v* tag 验证 Release 产出 Windows 安装包

Made with [Cursor](https://cursor.com)