### PR TITLE
ci: cross-platform desktop builds for macOS and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,19 @@ jobs:
       - name: Type check desktop
         run: pnpm --filter @bundy-lmw/hive-desktop exec tsc --noEmit
 
-  build-desktop-windows:
-    runs-on: windows-latest
+  # Native builds on each OS — matches Tauri docs (do not cross-compile SQLite/WebView).
+  # https://v2.tauri.app/distribute/pipelines/github
+  build-desktop:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            args: '--target aarch64-apple-darwin'
+          - platform: windows-latest
+            args: ''
+
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +65,8 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin' || '' }}
 
       - run: pnpm install
 
@@ -66,7 +79,12 @@ jobs:
       - name: Bundle server (SEA)
         run: node apps/server/scripts/bundle.mjs
 
-      - name: Build Tauri app (Windows)
-        run: pnpm --filter @bundy-lmw/hive-desktop tauri build
+      - name: Build Tauri app
+        uses: tauri-apps/tauri-action@v0.6
         env:
           CI: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: apps/desktop
+          args: ${{ matrix.args }}
+          # No releaseId → build only (verify compile + package on each OS)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,11 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
+          # Install host triple targets on each runner; macOS also builds aarch64 explicitly.
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin' || '' }}
 
       - name: Install system dependencies (ubuntu)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
@@ -105,12 +106,14 @@ jobs:
         run: pnpm --filter @bundy-lmw/hive-server build
 
       - name: Bundle server (SEA)
+        # Cross-platform: use bundle.mjs (not bash-only bundle.sh) so Windows gets node-win-x64.exe
         run: node apps/server/scripts/bundle.mjs
 
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Unsigned Windows builds will trigger SmartScreen; see release body.
         with:
           projectPath: apps/desktop
           releaseId: ${{ needs.create-release.outputs.release_id }}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -229,7 +229,16 @@ async fn spawn_server(state: &ServerState, force: bool) -> Result<(), String> {
                 server_dir.join("node-linux-arm64").to_string_lossy().to_string()
             };
             #[cfg(target_os = "windows")]
-            let node_bin = server_dir.join("node-win-x64").to_string_lossy().to_string();
+            let node_bin = {
+                let with_ext = server_dir.join("node-win-x64.exe");
+                let without_ext = server_dir.join("node-win-x64");
+                if with_ext.exists() {
+                    with_ext.to_string_lossy().to_string()
+                } else {
+                    // Fallback for older bundles that omitted the .exe suffix
+                    without_ext.to_string_lossy().to_string()
+                }
+            };
             (node_bin, vec!["main.js"], server_dir_str)
         } else {
             eprintln!(

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -33,6 +33,11 @@
     "macOS": {
       "signingIdentity": "-"
     },
+    "windows": {
+      "nsis": {
+        "installMode": "currentUser"
+      }
+    },
     "resources": {
       "../../server/bundle": "server"
     },

--- a/apps/server/scripts/bundle.mjs
+++ b/apps/server/scripts/bundle.mjs
@@ -160,12 +160,12 @@ if (existsSync(templatesSrc)) {
 console.log('[bundle] Step 4: Downloading Node.js binary...');
 
 const nodeVersion = execSync('node -v', { encoding: 'utf-8' }).trim().replace(/^v/, '');
-const nodeSideName = `node-${NODE_ARCH}`;
+const isWindows = plat === 'win32';
+// Windows CreateProcess appends .exe when path has no extension — ship as node-win-x64.exe
+const nodeSideName = isWindows ? `node-${NODE_ARCH}.exe` : `node-${NODE_ARCH}`;
 const tmpDir = resolve(OUT_DIR, '..', '.tmp-bundle');
 
 mkdirSync(tmpDir, { recursive: true });
-
-const isWindows = plat === 'win32';
 
 let nodeBinPath;
 if (isWindows) {

--- a/apps/server/scripts/bundle.sh
+++ b/apps/server/scripts/bundle.sh
@@ -131,6 +131,7 @@ if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; t
     unzip -qo "$NODE_ZIP" -d /tmp/
     rm -f "$NODE_ZIP"
   fi
+  NODE_SIDE_NAME="node-${NODE_ARCH}.exe"
 else
   NODE_TAR="/tmp/node-v${NODE_VERSION}-${NODE_ARCH}.tar.gz"
   NODE_BIN="/tmp/node-v${NODE_VERSION}-${NODE_ARCH}/bin/node"
@@ -141,10 +142,13 @@ else
     tar -xf "$NODE_TAR" -C /tmp/
     rm -f "$NODE_TAR"
   fi
+  NODE_SIDE_NAME="node-${NODE_ARCH}"
 fi
 
 cp "$NODE_BIN" "$OUT_DIR/$NODE_SIDE_NAME"
-chmod +x "$OUT_DIR/$NODE_SIDE_NAME"
+if [[ "$OSTYPE" != "msys" && "$OSTYPE" != "cygwin" && "$OSTYPE" != "win32" ]]; then
+  chmod +x "$OUT_DIR/$NODE_SIDE_NAME"
+fi
 
 BINARY_SIZE=$(du -h "$OUT_DIR/$NODE_SIDE_NAME" | cut -f1)
 TOTAL_SIZE=$(du -sh "$OUT_DIR" | cut -f1)


### PR DESCRIPTION
## Summary
- CI `build-desktop` 改为 macOS + Windows 原生矩阵（对齐 [Tauri GitHub pipeline](https://v2.tauri.app/distribute/pipelines/github)，避免交叉编译 SQLite/WebView）
- Windows sidecar 输出改为 `node-win-x64.exe`（CreateProcess 可靠启动）
- `tauri.conf.json` 增加 NSIS `installMode: currentUser`

## Test plan
- [x] cargo check (macOS)
- [x] node --check bundle.mjs
- [ ] CI build-desktop / macos-latest
- [ ] CI build-desktop / windows-latest

Made with [Cursor](https://cursor.com)