### PR TITLE
fix(website): show Windows download on landing page

### DIFF
--- a/website/components/hero.tsx
+++ b/website/components/hero.tsx
@@ -14,6 +14,16 @@ export async function Hero() {
   };
 
   for (const asset of assets) {
+    const current = assetsByPlatform[asset.platform];
+    // Prefer installer exe over msi when both exist
+    if (
+      asset.platform === 'windows' &&
+      current.url &&
+      current.name?.endsWith('.exe') &&
+      asset.name.endsWith('.msi')
+    ) {
+      continue;
+    }
     assetsByPlatform[asset.platform] = { url: asset.url, name: asset.name };
   }
 

--- a/website/components/terminal-install.tsx
+++ b/website/components/terminal-install.tsx
@@ -83,12 +83,44 @@ export function TerminalInstall({ assets, tagName, installCommand }: TerminalIns
         )}
 
         {/* Windows Tab */}
-        {activeTab === 'windows' && (
+        {activeTab === 'windows' && assets.windows.url && (
+          <a
+            href={assets.windows.url}
+            className="group flex items-center gap-3 rounded-xl bg-amber-500 px-5 py-3.5 font-semibold text-black transition-all hover:bg-amber-400 hover:shadow-lg hover:shadow-amber-500/20"
+          >
+            <Download size={18} className="shrink-0" />
+            <div className="flex flex-1 items-baseline gap-2">
+              <span>{assets.windows.name ?? 'Hive-setup.exe'}</span>
+              {tagName && (
+                <span className="text-sm font-normal opacity-60">{tagName}</span>
+              )}
+            </div>
+            <Package size={14} className="opacity-50" />
+          </a>
+        )}
+
+        {activeTab === 'windows' && !assets.windows.url && (
           <div className="py-2 text-center text-sm text-text-muted">{t('comingSoon')}</div>
         )}
 
         {/* Linux Tab */}
-        {activeTab === 'linux' && (
+        {activeTab === 'linux' && assets.linux.url && (
+          <a
+            href={assets.linux.url}
+            className="group flex items-center gap-3 rounded-xl bg-amber-500 px-5 py-3.5 font-semibold text-black transition-all hover:bg-amber-400 hover:shadow-lg hover:shadow-amber-500/20"
+          >
+            <Download size={18} className="shrink-0" />
+            <div className="flex flex-1 items-baseline gap-2">
+              <span>{assets.linux.name ?? 'Hive.AppImage'}</span>
+              {tagName && (
+                <span className="text-sm font-normal opacity-60">{tagName}</span>
+              )}
+            </div>
+            <Package size={14} className="opacity-50" />
+          </a>
+        )}
+
+        {activeTab === 'linux' && !assets.linux.url && (
           <div className="py-2 text-center text-sm text-text-muted">{t('comingSoon')}</div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Release \`v0.5.1\` already has \`Hive_0.5.1_x64-setup.exe\` (+ msi)
- Landing page Windows tab was hardcoded to「开发中」— now mirrors macOS download button
- Prefer \`.exe\` over \`.msi\` when both are present

## Test plan
- [ ] Deploy website; open Windows tab → download button for \`Hive_0.5.1_x64-setup.exe\`
- [ ] Proxy URL works: \`/download/v0.5.1/Hive_0.5.1_x64-setup.exe\`

Made with [Cursor](https://cursor.com)