### PR TITLE
feat(office): 自有视觉管线 — 场景契约与完成闸 (#140)

### DIFF
--- a/apps/server/src/officecli-skill-content.ts
+++ b/apps/server/src/officecli-skill-content.ts
@@ -77,17 +77,27 @@ officecli get deck.pptx '/slide[1]/shape[1]' --json
 {"success":false,"error":{"error":"Slide 50 not found","code":"not_found","suggestion":"Valid range: 1-8"}}
 \`\`\`
 
+## 视觉契约（PPT）
+
+- 数据 / KPI / 趋势 / 对比任务：必须有**真 chart** 或 **picture 嵌入**（SVG/PNG）。禁止用色块矩形冒充柱状图。
+- 流程 / 架构图：先写 SVG 再 \`add --type picture --prop src=...\`；优先直接嵌 SVG，不行再用 rsvg-convert/magick 转 PNG。
+- 交付前必跑 \`officecli view <file> outline\` 与 \`view … issues\`（或 html）；有重叠则先修再 send-file。
+- 版式槽（cm，页 25.4×19.05）：标题 y≈4–7；双栏左 x=1–12 / 右 x=13–24 y=2.5–16；数据图区 x=1.5–23 y=3–15。
+
 ## 典型工作流
 
 ### 创建 PPT
 
 \`\`\`bash
 officecli create report.pptx
-officecli add report.pptx / --type slide --prop title="Q4 Results"
+officecli add report.pptx / --type slide --prop layout=blank --prop title="Q4 Results"
 officecli add report.pptx '/slide[1]' --type shape \\
-  --prop text="Revenue: $4.2M" --prop x=2cm --prop y=5cm --prop size=28
-officecli add report.pptx / --type slide --prop title="Details"
+  --prop text="Q4 Results" --prop x=2cm --prop y=4cm --prop size=36 --prop bold=true
+# 数据页：chart 或 picture，禁止色块假柱
+officecli add report.pptx / --type slide --prop layout=blank
+officecli add report.pptx '/slide[2]' --type picture --prop src=./chart.svg --prop x=1.5cm --prop y=3cm
 officecli view report.pptx outline
+officecli view report.pptx issues
 officecli validate report.pptx
 \`\`\`
 

--- a/packages/core/src/agents/completion/office-slide-count.ts
+++ b/packages/core/src/agents/completion/office-slide-count.ts
@@ -1,11 +1,21 @@
 /**
- * PPTX slide counting for completion verification (no officecli dependency).
+ * PPTX zip inspection for completion verification (no officecli dependency).
+ * One `unzip -l` yields slide count + chart/media presence.
  */
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
+
+export interface PptxZipInfo {
+  /** null if unzip failed or not a pptx */
+  slideCount: number | null;
+  hasChart: boolean;
+  hasMedia: boolean;
+  /** false when unzip failed / skipped */
+  ok: boolean;
+}
 
 /** Parse "8页" / "8 页" / "8 slides" from user task */
 export function extractExpectedSlideCount(task: string): number | null {
@@ -16,14 +26,28 @@ export function extractExpectedSlideCount(task: string): number | null {
   return null;
 }
 
+/** Single unzip -l pass: slides + visual media flags */
+export async function inspectPptxZip(filePath: string): Promise<PptxZipInfo> {
+  if (!filePath.toLowerCase().endsWith('.pptx')) {
+    return { slideCount: null, hasChart: false, hasMedia: false, ok: false };
+  }
+  try {
+    // `--` so paths starting with `-` are not parsed as unzip flags
+    const { stdout } = await execFileAsync('unzip', ['-l', '--', filePath], { timeout: 15_000 });
+    const matches = stdout.match(/ppt\/slides\/slide\d+\.xml/gi);
+    return {
+      slideCount: matches?.length ?? 0,
+      hasChart: /ppt\/charts\//i.test(stdout),
+      hasMedia: /ppt\/media\//i.test(stdout),
+      ok: true,
+    };
+  } catch {
+    return { slideCount: null, hasChart: false, hasMedia: false, ok: false };
+  }
+}
+
 /** Count slides via unzip listing (ppt/slides/slideN.xml) */
 export async function countPptxSlides(filePath: string): Promise<number | null> {
-  if (!filePath.toLowerCase().endsWith('.pptx')) return null;
-  try {
-    const { stdout } = await execFileAsync('unzip', ['-l', filePath], { timeout: 15_000 });
-    const matches = stdout.match(/ppt\/slides\/slide\d+\.xml/gi);
-    return matches?.length ?? null;
-  } catch {
-    return null;
-  }
+  const info = await inspectPptxZip(filePath);
+  return info.ok ? info.slideCount : null;
 }

--- a/packages/core/src/agents/completion/office-visual-contract.ts
+++ b/packages/core/src/agents/completion/office-visual-contract.ts
@@ -1,0 +1,101 @@
+/**
+ * Office PPT visual contract heuristics (data intent, media presence, layout scan).
+ * Completion verifier must not invoke officecli — unzip + TaskTrace only.
+ */
+
+import type { TaskTrace } from './types.js';
+import { inspectPptxZip } from './office-slide-count.js';
+
+export const FAKE_CHART_PREFIX = '[FAKE_CHART]';
+export const LAYOUT_ISSUES_PREFIX = '[LAYOUT_ISSUES]';
+
+/** Positive: task needs chart or embedded picture in the deck */
+const POSITIVE_PATTERNS: RegExp[] = [
+  /图表/,
+  /\bchart\b/i,
+  /数据/,
+  /\bKPI\b/i,
+  /同比/,
+  /环比/,
+  /趋势/,
+  /占比/,
+  /柱状/,
+  /折线/,
+  /饼图/,
+  /对比/,
+  /增长/,
+  /百分点/,
+  /\brevenue\b/i,
+  /\bmetrics?\b/i,
+];
+
+/** Negative phrases win over positive substring matches */
+const NEGATIVE_PATTERNS: RegExp[] = [
+  /纯文字提纲/,
+  /议程/,
+  /标题页/,
+  /会议纪要大纲/,
+  /无数据/,
+  /文字版/,
+];
+
+const LAYOUT_ISSUE_RE =
+  /\b(overlap|collision|overlapping)\b|重叠|遮挡|互相覆盖|layout\s*issue/i;
+
+function safeString(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value == null) return '';
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * View-like call: require officecli view in the *input* (or a tool named *view*).
+ * Do not infer from output text alone — avoids false LAYOUT fails.
+ */
+function isViewRelatedCall(toolName: string, input: unknown, _output: unknown): boolean {
+  const name = toolName.toLowerCase();
+  if (/(^|[^a-z])view([^a-z]|$)/i.test(name) || name.endsWith('view')) return true;
+  const inp = safeString(input).toLowerCase();
+  return /\bofficecli\b/.test(inp) && /\bview\b/.test(inp);
+}
+
+export function hasDataVisualIntent(task: string): boolean {
+  if (!task.trim()) return false;
+  if (NEGATIVE_PATTERNS.some(re => re.test(task))) return false;
+  return POSITIVE_PATTERNS.some(re => re.test(task));
+}
+
+/**
+ * true = chart or picture part present; false = inspected, none;
+ * null = could not inspect (unzip failed).
+ */
+export async function pptxHasVisualMedia(filePath: string): Promise<boolean | null> {
+  const info = await inspectPptxZip(filePath);
+  if (!info.ok) return null;
+  return info.hasChart || info.hasMedia;
+}
+
+/** Whether LAYOUT gate should run (had view-like tool output to scan). */
+export function hasScannableViewOutput(trace: TaskTrace): boolean {
+  return trace.toolCalls.some(call => {
+    if (!isViewRelatedCall(call.toolName, call.input, call.output)) return false;
+    return safeString(call.output).trim().length > 0;
+  });
+}
+
+/** Return matched issue token, or null if no issue / nothing to scan. */
+export function findLayoutIssueInTrace(trace: TaskTrace): string | null {
+  if (!hasScannableViewOutput(trace)) return null;
+  for (const call of trace.toolCalls) {
+    if (!isViewRelatedCall(call.toolName, call.input, call.output)) continue;
+    const text = safeString(call.output);
+    if (LAYOUT_ISSUE_RE.test(text)) {
+      return text.match(LAYOUT_ISSUE_RE)?.[0] ?? 'layout issue';
+    }
+  }
+  return null;
+}

--- a/packages/core/src/agents/completion/verifiers/office.ts
+++ b/packages/core/src/agents/completion/verifiers/office.ts
@@ -7,7 +7,13 @@ import { isOfficeDocumentPath } from '../../../artifacts/artifact-detector.js';
 import { isOfficeTask } from '../../../routing/scenarios/office.scenario.js';
 import type { CompletionVerifier, TaskTrace, VerifyResult } from '../types.js';
 import { getAgentWorkerTypes, getSpawnedWorkerTypes } from '../TaskTrace.js';
-import { countPptxSlides, extractExpectedSlideCount } from '../office-slide-count.js';
+import { extractExpectedSlideCount, inspectPptxZip } from '../office-slide-count.js';
+import {
+  FAKE_CHART_PREFIX,
+  LAYOUT_ISSUES_PREFIX,
+  findLayoutIssueInTrace,
+  hasDataVisualIntent,
+} from '../office-visual-contract.js';
 
 async function fileExists(path: string): Promise<boolean> {
   try {
@@ -63,7 +69,8 @@ export const officeCompletionVerifier: CompletionVerifier = {
 
     const pptx = docs.find(a => a.toLowerCase().endsWith('.pptx'));
     if (pptx) {
-      const actual = await countPptxSlides(pptx);
+      const zip = await inspectPptxZip(pptx);
+      const actual = zip.ok ? zip.slideCount : null;
       const expected = extractExpectedSlideCount(trace.task);
 
       if (actual != null && actual < 2) {
@@ -89,6 +96,38 @@ export const officeCompletionVerifier: CompletionVerifier = {
             message: `PPT slide count mismatch: user asked for ${expected} pages but file has ${actual} slides. Add missing slides before claiming completion.`,
           };
         }
+      }
+
+      if (hasDataVisualIntent(trace.task)) {
+        if (!zip.ok) {
+          return {
+            verifierId: 'office',
+            passed: false,
+            message:
+              `${FAKE_CHART_PREFIX} Could not inspect ${pptx} for charts/media. `
+              + 'Ensure the file is a valid pptx with a real chart or picture, then send-file again.',
+          };
+        }
+        if (!(zip.hasChart || zip.hasMedia)) {
+          return {
+            verifierId: 'office',
+            passed: false,
+            message:
+              `${FAKE_CHART_PREFIX} Data/visual task requires a real chart (ppt/charts) or embedded picture (ppt/media). `
+              + 'Do not use colored rectangles as fake bars. Add chart or SVG/PNG via picture, then send-file.',
+          };
+        }
+      }
+
+      const layoutHit = findLayoutIssueInTrace(trace);
+      if (layoutHit) {
+        return {
+          verifierId: 'office',
+          passed: false,
+          message:
+            `${LAYOUT_ISSUES_PREFIX} Layout problem detected in officecli view output (${layoutHit}). `
+            + 'Fix overlapping shapes using layout slots, re-run view, then send-file.',
+        };
       }
 
       if (actual != null) {

--- a/packages/core/src/agents/prompts/templates/office.md
+++ b/packages/core/src/agents/prompts/templates/office.md
@@ -9,25 +9,49 @@ You are an Office document specialist. Create professional PowerPoint, Word, and
 - Never "deliver" by only writing a disk path, a link, or "文件位置：…" — users cannot open those from chat.
 - Never claim screenshots or pages are "shown / 已显示" unless you called **send-file** on those image files and they appear as chat attachments. Imagining previews does not count.
 - Prefer one final **send-file** of the Office file. Use screenshot + send-file only when the user explicitly asks for page images; still send-file the `.pptx` first.
-- **Before send-file**: run `officecli view <file> outline` and confirm slide/page count matches the user's request. If short, add slides — never claim a page count you did not build.
+- **Before send-file**: run `officecli view <file> outline` and `officecli view <file> issues` (or html). Confirm slide/page count matches the request. Fix layout issues before claiming done.
+
+## Visual contract (PPT — mandatory)
+
+- Data / KPI / trend / comparison / chart tasks: the deck MUST include a **real chart** (`officecli add … --type chart` when supported) **or** an embedded picture (SVG/PNG via `--type picture`). Colored rectangles pretending to be bars are **forbidden** and do not count as done.
+- Architecture / process diagrams: prefer SVG written to a workspace file, then `officecli add … --type picture --prop src=<path>`. Prefer embedding SVG directly; if the CLI rejects SVG, rasterize with `rsvg-convert` or `magick` to PNG then embed.
+- Never tell the user the deck is ready if title/body shapes **overlap**. Use the layout slots below.
 
 ## Design Principles
 
 - Clean, professional layouts with proper spacing
-- Use blank layouts and position content manually for full control
+- Prefer the layout slots below (not freehand overlapping coordinates)
 - Consistent color scheme: use 2-3 colors max per presentation
 - Font sizes: titles 32-40pt, body 18-24pt, small text 12-14pt
 - Leave breathing room — don't overcrowd slides
-- For data slides, use shapes for visual elements (not just text)
+- For data slides, use real charts or picture embeds — never fake bars from shapes
+
+## Layout slots (cm; slide 25.4 × 19.05)
+
+**Title slide**
+- Title: x=2–22, y=4–7, size 36–40
+- Subtitle: y=7.5–9
+
+**Two-column**
+- Title band: y=0.5–2
+- Left: x=1–12, y=2.5–16
+- Right: x=13–24, y=2.5–16
+
+**Data + chart/picture**
+- Title: y=0.5–2
+- Chart/picture: x=1.5–23, y=3–15
+- Caption: y=15.5–17
+
+Flow diagrams may use shapes/arrows inside slots. Do **not** fake a series chart with equal-width colored bars + `%` labels.
 
 ## PPT Creation Workflow
 
 1. `officecli create <file>.pptx`
 2. Add slides with `officecli add <file> / --type slide --prop layout=blank`
-3. Add title shapes: `--type shape --prop text="Title" --prop x=1cm --prop y=1cm --prop size=36 --prop bold=true`
-4. Add body shapes with proper positioning
-5. Add visual elements (shapes for charts, colored backgrounds)
-6. `officecli view <file> html` to verify the result
+3. Place text using a layout slot (title / two-col / data)
+4. For data: add chart **or** write SVG → add picture
+5. `officecli view <file> outline` then `officecli view <file> issues` (or html) — fix overlaps
+6. `send-file` the `.pptx`
 
 ## Common Slide Patterns
 
@@ -35,21 +59,24 @@ You are an Office document specialist. Create professional PowerPoint, Word, and
 ```
 officecli add file.pptx / --type slide --prop layout=blank --prop background=1A1A2E
 officecli add file.pptx '/slide[1]' --type shape --prop text="Title" --prop x=2cm --prop y=4cm --prop size=40 --prop bold=true --prop color=FFFFFF
-officecli add file.pptx '/slide[1]' --type shape --prop text="Subtitle" --prop x=2cm --prop y=6cm --prop size=18 --prop color=AAAAAA
+officecli add file.pptx '/slide[1]' --type shape --prop text="Subtitle" --prop x=2cm --prop y=7.5cm --prop size=18 --prop color=AAAAAA
 ```
 
 **Content Slide:**
 ```
 officecli add file.pptx / --type slide --prop layout=blank --prop background=FFFFFF
 officecli add file.pptx '/slide[N]' --type shape --prop text="Section Title" --prop x=1cm --prop y=0.5cm --prop size=28 --prop bold=true --prop color=1A1A2E
-officecli add file.pptx '/slide[N]' --type shape --prop text="Bullet 1\nBullet 2\nBullet 3" --prop x=1cm --prop y=2cm --prop size=16 --prop color=333333
+officecli add file.pptx '/slide[N]' --type shape --prop text="Bullet 1\nBullet 2\nBullet 3" --prop x=1cm --prop y=2.5cm --prop size=16 --prop color=333333
 ```
 
-**Data/KPI Slide:**
+**Data / chart slide (required pattern for data tasks):**
 ```
 officecli add file.pptx / --type slide --prop layout=blank --prop background=F8F9FA
-officecli add file.pptx '/slide[N]' --type shape --prop text="42%" --prop x=1cm --prop y=2cm --prop size=48 --prop bold=true --prop color=2563EB
-officecli add file.pptx '/slide[N]' --type shape --prop text="Revenue Growth" --prop x=1cm --prop y=4cm --prop size=14 --prop color=666666
+officecli add file.pptx '/slide[N]' --type shape --prop text="Revenue Growth" --prop x=1.5cm --prop y=0.5cm --prop size=28 --prop bold=true
+# Prefer native chart when available:
+# officecli add file.pptx '/slide[N]' --type chart --prop ...
+# Or embed SVG/PNG:
+# officecli add file.pptx '/slide[N]' --type picture --prop src=./chart.svg --prop x=1.5cm --prop y=3cm --prop width=22cm --prop height=12cm
 ```
 
 ## Color Palettes
@@ -63,15 +90,13 @@ officecli add file.pptx '/slide[N]' --type shape --prop text="Revenue Growth" --
 ## Positioning
 
 Use cm units. A standard slide is 25.4cm × 19.05cm.
-- Title area: y=0.5cm to y=2cm
-- Content area: y=2.5cm to y=17cm
-- Footer: y=17.5cm to y=18.5cm
-- Left margin: x=1cm, right margin: x=23cm
+- Stay inside the layout slot for that slide type
+- Left margin ~1cm, right ~23–24cm max content edge
 
 ## Tips
 
-- When adding many shapes to a slide, increment x/y to space them evenly
+- When adding many shapes, keep them inside one slot column — never stack two text boxes on the same y-band
 - Use `officecli view <file> outline` to check slide structure
+- Use `officecli view <file> issues` to catch overlap before send-file
 - Use `officecli validate <file>` after creating to catch errors
-- For charts, create colored rectangles as bars and add percentage labels
 - Keep text concise — slides are visual aids, not documents

--- a/packages/core/tests/unit/completion/completion-verifier.test.ts
+++ b/packages/core/tests/unit/completion/completion-verifier.test.ts
@@ -2,14 +2,16 @@
  * CompletionVerifier 单元测试
  */
 
-import { describe, it, expect } from 'vitest';
-import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { writeFile, mkdir, rm, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { CompletionVerifierService } from '../../../src/agents/completion/CompletionVerifier.js';
 import { officeCompletionVerifier } from '../../../src/agents/completion/verifiers/office.js';
 import { scheduleCompletionVerifier } from '../../../src/agents/completion/verifiers/schedule.js';
+import { FAKE_CHART_PREFIX, LAYOUT_ISSUES_PREFIX } from '../../../src/agents/completion/office-visual-contract.js';
 import type { TaskTrace } from '../../../src/agents/completion/types.js';
+import { buildPptxFixture } from './pptx-fixture.js';
 
 function trace(overrides: Partial<TaskTrace>): TaskTrace {
   return {
@@ -92,6 +94,100 @@ describe('officeCompletionVerifier', () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  describe('visual contract', () => {
+    let root = '';
+    let bare = '';
+    let withMedia = '';
+    let withChart = '';
+
+    beforeAll(async () => {
+      root = join(tmpdir(), `hive-completion-visual-${Date.now()}`);
+      await mkdir(root, { recursive: true });
+      bare = await buildPptxFixture(root, 'bare', { slides: 2 });
+      withMedia = await buildPptxFixture(root, 'media', { slides: 2, media: true });
+      withChart = await buildPptxFixture(root, 'chart', { slides: 2, charts: true });
+    });
+
+    afterAll(async () => {
+      await rm(root, { recursive: true, force: true });
+    });
+
+    it('fails FAKE_CHART when data intent and no media', async () => {
+      const result = await officeCompletionVerifier.verify(trace({
+        task: '做一份带 KPI 趋势数据的 PPT',
+        workerSpawns: [{ workerType: 'office' }],
+        artifacts: [bare],
+      }));
+      expect(result.passed).toBe(false);
+      expect(result.message).toContain(FAKE_CHART_PREFIX);
+    });
+
+    it('fails FAKE_CHART when unzip cannot inspect pptx', async () => {
+      const junk = join(root, 'junk.pptx');
+      await writeFile(junk, 'not-a-zip');
+      const result = await officeCompletionVerifier.verify(trace({
+        task: '做一份带 KPI 数据的 PPT',
+        workerSpawns: [{ workerType: 'office' }],
+        artifacts: [junk],
+      }));
+      expect(result.passed).toBe(false);
+      expect(result.message).toContain(FAKE_CHART_PREFIX);
+      expect(result.message).toMatch(/Could not inspect/i);
+    });
+
+    it('passes data intent when media present', async () => {
+      const result = await officeCompletionVerifier.verify(trace({
+        task: '做一份带 KPI 趋势数据的 PPT',
+        workerSpawns: [{ workerType: 'office' }],
+        artifacts: [withMedia],
+      }));
+      expect(result.passed).toBe(true);
+    });
+
+    it('passes data intent when chart present without media', async () => {
+      const result = await officeCompletionVerifier.verify(trace({
+        task: '做一份带数据图表的 PPT',
+        workerSpawns: [{ workerType: 'office' }],
+        artifacts: [withChart],
+      }));
+      expect(result.passed).toBe(true);
+    });
+
+    it('does not require media for non-data agenda PPT', async () => {
+      const result = await officeCompletionVerifier.verify(trace({
+        task: '纯文字提纲议程 PPT',
+        workerSpawns: [{ workerType: 'office' }],
+        artifacts: [bare],
+      }));
+      expect(result.passed).toBe(true);
+    });
+
+    it('fails LAYOUT_ISSUES when view output reports overlap', async () => {
+      const result = await officeCompletionVerifier.verify(trace({
+        task: 'Create a PPT',
+        workerSpawns: [{ workerType: 'office' }],
+        artifacts: [withMedia],
+        toolCalls: [{
+          toolName: 'bash',
+          input: { command: 'officecli view deck.pptx issues' },
+          output: 'Found overlap on slide 1',
+        }],
+      }));
+      expect(result.passed).toBe(false);
+      expect(result.message).toContain(LAYOUT_ISSUES_PREFIX);
+    });
+  });
+
+  it('office.md forbids fake colored-rectangle charts', async () => {
+    const md = await readFile(
+      new URL('../../../src/agents/prompts/templates/office.md', import.meta.url),
+      'utf8',
+    );
+    expect(md.toLowerCase()).not.toContain('colored rectangles as bars');
+    expect(md).toMatch(/Visual contract|真 chart|picture/i);
+    expect(md).toMatch(/Layout slots/i);
   });
 });
 

--- a/packages/core/tests/unit/completion/office-slide-count.test.ts
+++ b/packages/core/tests/unit/completion/office-slide-count.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from 'vitest';
-import { extractExpectedSlideCount } from '../../../src/agents/completion/office-slide-count.js';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  countPptxSlides,
+  extractExpectedSlideCount,
+  inspectPptxZip,
+} from '../../../src/agents/completion/office-slide-count.js';
+import { buildPptxFixture } from './pptx-fixture.js';
 
 describe('office-slide-count', () => {
   it('extractExpectedSlideCount parses Chinese 页', () => {
@@ -13,5 +21,34 @@ describe('office-slide-count', () => {
 
   it('extractExpectedSlideCount returns null when unspecified', () => {
     expect(extractExpectedSlideCount('做一个项目汇报 PPT')).toBeNull();
+  });
+
+  describe('inspect / count', () => {
+    let root = '';
+    let deck = '';
+
+    beforeAll(async () => {
+      root = join(tmpdir(), `hive-slide-count-${Date.now()}`);
+      await mkdir(root, { recursive: true });
+      deck = await buildPptxFixture(root, 'deck', { slides: 3, media: true });
+    });
+
+    afterAll(async () => {
+      await rm(root, { recursive: true, force: true });
+    });
+
+    it('inspectPptxZip returns slide count and media', async () => {
+      const info = await inspectPptxZip(deck);
+      expect(info.ok).toBe(true);
+      expect(info.slideCount).toBe(3);
+      expect(info.hasMedia).toBe(true);
+    });
+
+    it('countPptxSlides wraps inspect', async () => {
+      expect(await countPptxSlides(deck)).toBe(3);
+      const junk = join(root, 'bad.pptx');
+      await writeFile(junk, 'x');
+      expect(await countPptxSlides(junk)).toBeNull();
+    });
   });
 });

--- a/packages/core/tests/unit/completion/office-visual-contract.test.ts
+++ b/packages/core/tests/unit/completion/office-visual-contract.test.ts
@@ -1,0 +1,146 @@
+/**
+ * office-visual-contract 单元测试
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  hasDataVisualIntent,
+  pptxHasVisualMedia,
+  findLayoutIssueInTrace,
+  hasScannableViewOutput,
+} from '../../../src/agents/completion/office-visual-contract.js';
+import { inspectPptxZip } from '../../../src/agents/completion/office-slide-count.js';
+import type { TaskTrace } from '../../../src/agents/completion/types.js';
+import { buildPptxFixture } from './pptx-fixture.js';
+
+function emptyTrace(overrides: Partial<TaskTrace> = {}): TaskTrace {
+  return {
+    task: '',
+    toolCalls: [],
+    workerSpawns: [],
+    artifacts: [],
+    responseText: '',
+    ...overrides,
+  };
+}
+
+describe('hasDataVisualIntent', () => {
+  it('hits positive lexicon', () => {
+    expect(hasDataVisualIntent('做一个带 KPI 趋势图表的 PPT')).toBe(true);
+    expect(hasDataVisualIntent('Add a revenue chart')).toBe(true);
+    expect(hasDataVisualIntent('展示同比增长数据')).toBe(true);
+  });
+
+  it('negative phrases win', () => {
+    expect(hasDataVisualIntent('纯文字提纲 PPT 议程')).toBe(false);
+    expect(hasDataVisualIntent('无数据的文字版标题页')).toBe(false);
+  });
+
+  it('does not treat bare percent as intent', () => {
+    expect(hasDataVisualIntent('100%完成议程 PPT')).toBe(false);
+  });
+
+  it('plain create PPT is not data intent', () => {
+    expect(hasDataVisualIntent('Create a PPT')).toBe(false);
+  });
+});
+
+describe('inspectPptxZip / pptxHasVisualMedia', () => {
+  let root = '';
+  let bare = '';
+  let withMedia = '';
+  let withChart = '';
+
+  beforeAll(async () => {
+    root = join(tmpdir(), `hive-visual-${Date.now()}`);
+    await mkdir(root, { recursive: true });
+    bare = await buildPptxFixture(root, 'bare', { slides: 2 });
+    withMedia = await buildPptxFixture(root, 'media', { slides: 2, media: true });
+    withChart = await buildPptxFixture(root, 'chart', { slides: 2, charts: true });
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('detects slides and media flags', async () => {
+    const info = await inspectPptxZip(withMedia);
+    expect(info.ok).toBe(true);
+    expect(info.slideCount).toBe(2);
+    expect(info.hasMedia).toBe(true);
+    expect(info.hasChart).toBe(false);
+  });
+
+  it('pptxHasVisualMedia true for charts or media', async () => {
+    expect(await pptxHasVisualMedia(bare)).toBe(false);
+    expect(await pptxHasVisualMedia(withMedia)).toBe(true);
+    expect(await pptxHasVisualMedia(withChart)).toBe(true);
+  });
+
+  it('returns null when unzip fails', async () => {
+    const junk = join(root, 'junk.pptx');
+    await writeFile(junk, 'not-a-zip');
+    expect(await pptxHasVisualMedia(junk)).toBeNull();
+  });
+});
+
+describe('layout scan from TaskTrace', () => {
+  it('skips when no view output', () => {
+    const t = emptyTrace({
+      toolCalls: [{ toolName: 'bash', input: { command: 'ls' }, output: 'ok' }],
+    });
+    expect(hasScannableViewOutput(t)).toBe(false);
+    expect(findLayoutIssueInTrace(t)).toBeNull();
+  });
+
+  it('ignores overlap in non-view tool output (no false positive)', () => {
+    const t = emptyTrace({
+      toolCalls: [{
+        toolName: 'bash',
+        input: { command: 'cat report.txt' },
+        output: 'Found overlap on slide 1; 文字重叠',
+      }],
+    });
+    expect(hasScannableViewOutput(t)).toBe(false);
+    expect(findLayoutIssueInTrace(t)).toBeNull();
+  });
+
+  it('detects overlap in view output', () => {
+    const t = emptyTrace({
+      toolCalls: [{
+        toolName: 'bash',
+        input: { command: 'officecli view deck.pptx issues' },
+        output: 'slide 2: text overlap with shape',
+      }],
+    });
+    expect(hasScannableViewOutput(t)).toBe(true);
+    expect(findLayoutIssueInTrace(t)).toMatch(/overlap/i);
+  });
+
+  it('detects Chinese layout tokens', () => {
+    for (const token of ['重叠', '遮挡', '互相覆盖'] as const) {
+      const t = emptyTrace({
+        toolCalls: [{
+          toolName: 'bash',
+          input: { command: 'officecli view deck.pptx issues' },
+          output: `问题: ${token} 在第2页`,
+        }],
+      });
+      expect(findLayoutIssueInTrace(t)).toBe(token);
+    }
+  });
+
+  it('ignores clean view output', () => {
+    const t = emptyTrace({
+      toolCalls: [{
+        toolName: 'bash',
+        input: { command: 'officecli view deck.pptx issues' },
+        output: 'No issues found',
+      }],
+    });
+    expect(findLayoutIssueInTrace(t)).toBeNull();
+  });
+});

--- a/packages/core/tests/unit/completion/pptx-fixture.ts
+++ b/packages/core/tests/unit/completion/pptx-fixture.ts
@@ -1,0 +1,34 @@
+/**
+ * Minimal pptx-like zip fixtures for completion / visual-contract tests.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+export async function buildPptxFixture(
+  root: string,
+  name: string,
+  opts: { slides?: number; media?: boolean; charts?: boolean } = {},
+): Promise<string> {
+  const dir = join(root, name);
+  await mkdir(join(dir, 'ppt', 'slides'), { recursive: true });
+  const n = opts.slides ?? 2;
+  for (let i = 1; i <= n; i++) {
+    await writeFile(join(dir, 'ppt', 'slides', `slide${i}.xml`), `<s${i}/>`);
+  }
+  if (opts.media) {
+    await mkdir(join(dir, 'ppt', 'media'), { recursive: true });
+    await writeFile(join(dir, 'ppt', 'media', 'image1.png'), 'png');
+  }
+  if (opts.charts) {
+    await mkdir(join(dir, 'ppt', 'charts'), { recursive: true });
+    await writeFile(join(dir, 'ppt', 'charts', 'chart1.xml'), '<c/>');
+  }
+  const out = join(root, `${name}.pptx`);
+  await execFileAsync('zip', ['-qr', out, 'ppt'], { cwd: dir });
+  return out;
+}


### PR DESCRIPTION
## Summary

- 新增 `office-visual-contract`：数据意图检测、`FAKE_CHART` / `LAYOUT_ISSUES` 完成闸；一次 `unzip -l` 同时检查页数与 `ppt/charts` / `ppt/media`
- 改写 `office.md` 与 officecli skill：禁止色块假柱、三版式槽、交付前必须 `view outline` + `view issues`
- 单测覆盖 visual contract、verifier 集成、pptx fixture（39 tests passed）

## Scope (wedge for #140)

本 PR 落地 **路径 B — 场景契约**，不新开平行场景：

| 本 PR | 后置 |
|-------|------|
| 真 chart / picture 嵌入要求 | 自有生图管线 |
| 布局槽 + view issues 闸 | HTML 整页截屏 |
| Prompt/skill 禁假柱 | 默认 `officecli new` |
| TaskTrace 扫 view 重叠 | Preview 评分徽章 |

## Test plan

- [x] `npx vitest run packages/core/tests/unit/completion/` — 39 passed
- [ ] 手动 E2E：3–5 页含真 chart/SVG 的 deck（可 merge 后补 demo）

Closes #140

Made with [Cursor](https://cursor.com)