### PR TITLE
feat(desktop): Codex-style background sessions + Office preview UX

### DIFF
--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -353,10 +353,11 @@ html.desktop-app * {
   align-items: center;
   gap: 0.5rem;
   margin: 0 0 0.625rem;
-  padding: 0.4rem 0.65rem;
-  border-radius: 0.5rem;
-  border: 1px solid oklch(0.35 0.02 75 / 0.45);
-  background: oklch(0.19 0 0 / 0.9);
+  padding: 0.3rem 0.15rem;
+  border-radius: 0;
+  border: none;
+  border-top: 1px solid oklch(0.3 0 0 / 0.4);
+  background: transparent;
   opacity: 0;
   transform: translateY(6px);
   transition:
@@ -390,19 +391,20 @@ html.desktop-app * {
   align-items: center;
   gap: 0.35rem;
   max-width: 12rem;
-  padding: 0.25rem 0.55rem;
+  padding: 0.2rem 0.5rem;
   border-radius: 0.375rem;
-  border: 1px solid oklch(0.4 0.04 75 / 0.4);
-  background: oklch(0.24 0.015 75 / 0.55);
-  color: oklch(0.88 0.01 75);
-  font-size: 0.75rem;
+  border: 1px solid oklch(0.34 0.02 75 / 0.4);
+  background: oklch(0.22 0.01 75 / 0.45);
+  color: oklch(0.78 0.01 75);
+  font-size: 0.72rem;
   line-height: 1.2;
-  transition: background 0.15s, border-color 0.15s;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
 
 .artifacts-strip__item:hover {
-  background: oklch(0.3 0.03 75 / 0.65);
-  border-color: oklch(0.55 0.08 75 / 0.5);
+  background: oklch(0.28 0.02 75 / 0.55);
+  border-color: oklch(0.42 0.04 75 / 0.5);
+  color: oklch(0.9 0.01 75);
 }
 
 .artifacts-strip__name {
@@ -1326,31 +1328,29 @@ html.desktop-app * {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.65rem 0.75rem;
-  border-radius: 0.75rem;
-  border: 1px solid oklch(0.32 0.01 75 / 0.7);
-  background: oklch(0.2 0.006 75 / 0.85);
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid oklch(0.32 0.01 75 / 0.5);
+  background: oklch(0.18 0.006 75 / 0.55);
 }
 
 .file-attachment--deliverable .file-attachment__row {
-  padding: 0.85rem 0.9rem;
-  border-color: oklch(0.72 0.12 75 / 0.45);
-  background:
-    linear-gradient(135deg, oklch(0.72 0.12 75 / 0.12), transparent 55%),
-    oklch(0.19 0.01 75 / 0.92);
-  box-shadow: 0 8px 24px oklch(0 0 0 / 0.22);
+  padding: 0.7rem 0.8rem;
+  border-color: oklch(0.38 0.04 75 / 0.55);
+  background: oklch(0.2 0.01 75 / 0.7);
+  box-shadow: none;
 }
 
 .file-attachment__icon {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
-  border-radius: 0.55rem;
-  color: oklch(0.82 0.12 75);
-  background: oklch(0.72 0.12 75 / 0.14);
-  border: 1px solid oklch(0.72 0.12 75 / 0.25);
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.45rem;
+  color: oklch(0.72 0.06 75);
+  background: oklch(0.28 0.02 75 / 0.55);
+  border: 1px solid oklch(0.35 0.02 75 / 0.45);
   flex-shrink: 0;
 }
 
@@ -1362,9 +1362,9 @@ html.desktop-app * {
 .file-attachment__eyebrow {
   margin: 0 0 0.2rem;
   font-size: 0.625rem;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  color: oklch(0.78 0.11 75);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: oklch(0.62 0.03 75);
 }
 
 .file-attachment__name {
@@ -1395,32 +1395,35 @@ html.desktop-app * {
 }
 
 .file-attachment__preview-btn {
-  padding: 0.35rem 0.7rem;
-  border-radius: 0.5rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 0.375rem;
   font-size: 0.75rem;
   font-weight: 500;
-  color: oklch(0.16 0 0);
-  background: oklch(0.94 0 0);
+  color: oklch(0.78 0.02 75);
+  background: oklch(0.28 0.01 75 / 0.7);
+  border: 1px solid oklch(0.38 0.02 75 / 0.45);
   transition:
     background 150ms ease,
-    transform 150ms ease,
+    border-color 150ms ease,
     opacity 150ms ease;
 }
 
 .file-attachment__preview-btn--primary {
-  padding: 0.45rem 0.9rem;
-  font-weight: 600;
-  color: oklch(0.18 0.02 75);
-  background: oklch(0.86 0.12 75);
+  padding: 0.35rem 0.75rem;
+  font-weight: 500;
+  color: oklch(0.92 0.02 75);
+  background: oklch(0.32 0.04 75 / 0.85);
+  border-color: oklch(0.5 0.08 75 / 0.45);
 }
 
 .file-attachment__preview-btn:hover:not(:disabled) {
-  background: oklch(1 0 0);
-  transform: scale(1.02);
+  background: oklch(0.34 0.02 75 / 0.85);
+  border-color: oklch(0.48 0.04 75 / 0.55);
 }
 
 .file-attachment__preview-btn--primary:hover:not(:disabled) {
-  background: oklch(0.9 0.11 75);
+  background: oklch(0.38 0.06 75 / 0.9);
+  border-color: oklch(0.58 0.1 75 / 0.5);
 }
 
 .file-attachment__preview-btn:disabled {
@@ -1454,16 +1457,30 @@ html.desktop-app * {
 }
 
 .activity-card {
-  margin: 0.5rem 0;
+  margin: 0.45rem 0;
   border-radius: 0.5rem;
-  border: 1px solid oklch(0.35 0 0 / 0.55);
-  background: oklch(0.22 0 0 / 0.45);
+  border: 1px solid oklch(0.32 0 0 / 0.5);
+  background: oklch(0.18 0 0 / 0.4);
   overflow: hidden;
 }
 
 .activity-card--running {
-  border-color: oklch(0.728 0.164 75 / 0.28);
-  box-shadow: 0 0 0 1px oklch(0.728 0.164 75 / 0.08);
+  border-color: oklch(0.45 0.06 75 / 0.4);
+  box-shadow: none;
+}
+
+/* Quiet nested deliverables — avoid box-in-box glare */
+.activity-card__deliverables .file-attachment {
+  margin: 0.15rem 0;
+}
+
+.activity-card__deliverables .file-attachment__row {
+  border-color: oklch(0.3 0.01 75 / 0.4);
+  background: oklch(0.16 0.005 75 / 0.5);
+}
+
+.activity-card .office-progress-banner {
+  margin: 0.35rem 0.5rem;
 }
 
 .activity-card__pulse-dot,
@@ -1565,6 +1582,89 @@ html.desktop-app * {
 }
 
 /* ============================================
+   Session run badge (sidebar)
+   ============================================ */
+.session-run-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  flex-shrink: 0;
+  margin: 0.2rem 0.15rem 0;
+}
+.session-run-dot--running {
+  background: oklch(0.72 0.14 75);
+  box-shadow: 0 0 0 0 oklch(0.72 0.14 75 / 0.5);
+  animation: session-run-pulse 1.8s ease-out infinite;
+}
+.session-run-dot--waiting {
+  background: oklch(0.7 0.12 55);
+  animation: session-run-pulse 2.4s ease-out infinite;
+}
+@keyframes session-run-pulse {
+  0% { box-shadow: 0 0 0 0 oklch(0.72 0.12 70 / 0.45); }
+  70% { box-shadow: 0 0 0 0.35rem oklch(0.72 0.12 70 / 0); }
+  100% { box-shadow: 0 0 0 0 oklch(0.72 0.12 70 / 0); }
+}
+
+/* ============================================
+   Background run toasts
+   ============================================ */
+.bg-toast-host {
+  position: absolute;
+  right: 0.75rem;
+  bottom: 5.5rem;
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-width: min(22rem, calc(100% - 1.5rem));
+  pointer-events: none;
+}
+.bg-toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 0.5rem;
+  border: 1px solid oklch(0.35 0.02 75 / 0.55);
+  background: oklch(0.2 0.01 75 / 0.94);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 8px 24px oklch(0 0 0 / 0.35);
+}
+.bg-toast--waiting {
+  border-color: oklch(0.55 0.1 55 / 0.55);
+}
+.bg-toast__body {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  color: oklch(0.85 0.02 75);
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
+.bg-toast__body:hover {
+  color: oklch(0.92 0.03 75);
+}
+.bg-toast__dismiss {
+  flex-shrink: 0;
+  padding: 0.2rem;
+  border-radius: 0.25rem;
+  border: 0;
+  background: transparent;
+  color: oklch(0.55 0.01 75);
+  cursor: pointer;
+}
+.bg-toast__dismiss:hover {
+  color: oklch(0.8 0.02 75);
+  background: oklch(0.28 0.01 75 / 0.6);
+}
+
+/* ============================================
    Activity dock — sticky status bar
    ============================================ */
 .activity-dock {
@@ -1660,19 +1760,22 @@ html.desktop-app * {
 
 .office-progress-banner {
   display: block;
-  margin: 0 0 0.4rem;
-  padding: 0.35rem 0.55rem;
+  margin: 0.35rem 0;
+  padding: 0.4rem 0.65rem;
   font-size: 0.75rem;
   line-height: 1.4;
-  color: oklch(0.42 0.02 75);
-  background: oklch(0.97 0.005 75);
-  border-left: 2px solid oklch(0.72 0.04 145);
+  color: oklch(0.78 0.02 75);
+  background: oklch(0.2 0.008 75 / 0.65);
+  border: 1px solid oklch(0.32 0.01 75 / 0.45);
+  border-left: 2px solid oklch(0.68 0.1 75 / 0.75);
+  border-radius: 0.375rem;
 }
 
 .office-progress-banner--blocked {
-  color: oklch(0.45 0.08 35);
-  border-left-color: oklch(0.65 0.12 35);
-  background: oklch(0.97 0.02 35);
+  color: oklch(0.82 0.08 35);
+  border-color: oklch(0.4 0.06 35 / 0.45);
+  border-left-color: oklch(0.68 0.14 35);
+  background: oklch(0.22 0.03 35 / 0.45);
 }
 
 .worker-lane {
@@ -1685,7 +1788,7 @@ html.desktop-app * {
 .worker-lane__banner {
   font-size: 0.72rem;
   letter-spacing: 0.02em;
-  color: oklch(0.45 0.03 145);
+  color: oklch(0.55 0.02 75);
 }
 
 .worker-lane__grid {

--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -135,9 +135,8 @@ html.desktop-app * {
    Chat stage — sizes relative to main pane (container queries)
    ============================================ */
 .chat-stage {
-  /* Must use cqi (not %): --preview-width is also read by absolute sidebar / inner.
-     % resolves against the using element → inner collapses to ~8rem and looks "broken". */
-  --preview-width: clamp(22rem, 32cqi, 28rem);
+  /* Overridden inline by ChatPage when preview is open (user-resizable). */
+  --preview-width: 52rem;
   --chat-gutter: 1rem;
   --chat-rail-max: min(48rem, calc(100% - 2rem));
   --chat-composer-max: min(42rem, calc(100% - 2rem));
@@ -771,7 +770,6 @@ html.desktop-app * {
   .chat-stage {
     --chat-rail-max: 52rem;
     --chat-composer-max: 44rem;
-    --preview-width: clamp(24rem, 30cqi, 30rem);
   }
 }
 
@@ -779,7 +777,6 @@ html.desktop-app * {
   .chat-stage {
     --chat-rail-max: 56rem;
     --chat-composer-max: 46rem;
-    --preview-width: clamp(26rem, 28cqi, 32rem);
   }
 }
 
@@ -793,7 +790,7 @@ html.desktop-app * {
   bottom: 0;
   width: 0;
   z-index: 30;
-  overflow: hidden;
+  overflow: visible;
   background: oklch(0.13 0 0);
   border-left: 1px solid oklch(0.28 0 0 / 0.65);
   box-shadow: -10px 0 28px oklch(0 0 0 / 0.28);
@@ -802,8 +799,125 @@ html.desktop-app * {
 }
 
 .preview-sidebar--open {
-  width: var(--preview-width);
   pointer-events: auto;
+}
+
+body.preview-resizing,
+body.preview-resizing * {
+  cursor: col-resize !important;
+  user-select: none !important;
+}
+
+body.preview-resizing .preview-sidebar,
+body.preview-resizing .chat-stage {
+  transition: none !important;
+}
+
+.preview-sidebar__resizer {
+  position: absolute;
+  top: 0;
+  left: -8px;
+  bottom: 0;
+  width: 16px;
+  z-index: 40;
+  cursor: col-resize;
+  touch-action: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Always-visible amber seam — readable at rest, brighter on hover */
+.preview-sidebar__resizer::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  border-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    oklch(0.45 0.03 75 / 0.05) 0%,
+    oklch(0.68 0.1 75 / 0.55) 14%,
+    oklch(0.78 0.13 75 / 0.82) 50%,
+    oklch(0.68 0.1 75 / 0.55) 86%,
+    oklch(0.45 0.03 75 / 0.05) 100%
+  );
+  box-shadow: 0 0 12px oklch(0.72 0.12 75 / 0.22);
+  transition: width 160ms ease, background 160ms ease, box-shadow 160ms ease;
+}
+
+/* Center grip pill — three dots read as a drag affordance */
+.preview-sidebar__resizer-grip {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  width: 12px;
+  height: 44px;
+  border-radius: 999px;
+  background: oklch(0.24 0.025 75 / 0.96);
+  border: 1px solid oklch(0.72 0.12 75 / 0.55);
+  box-shadow:
+    0 2px 6px oklch(0 0 0 / 0.4),
+    0 0 0 1px oklch(0.72 0.12 75 / 0.12),
+    inset 0 1px 0 oklch(1 0 0 / 0.07);
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.preview-sidebar__resizer-grip span {
+  display: block;
+  width: 3.5px;
+  height: 3.5px;
+  border-radius: 999px;
+  background: oklch(0.8 0.12 75 / 0.92);
+  transition: background 160ms ease;
+}
+
+.preview-sidebar__resizer:hover::before,
+.preview-sidebar__resizer:focus-visible::before,
+body.preview-resizing .preview-sidebar__resizer::before {
+  width: 3px;
+  background: linear-gradient(
+    180deg,
+    oklch(0.5 0.04 75 / 0.1) 0%,
+    oklch(0.75 0.13 75 / 0.85) 12%,
+    oklch(0.85 0.14 75 / 1) 50%,
+    oklch(0.75 0.13 75 / 0.85) 88%,
+    oklch(0.5 0.04 75 / 0.1) 100%
+  );
+  box-shadow: 0 0 16px oklch(0.75 0.13 75 / 0.42);
+}
+
+.preview-sidebar__resizer:hover .preview-sidebar__resizer-grip,
+.preview-sidebar__resizer:focus-visible .preview-sidebar__resizer-grip,
+body.preview-resizing .preview-sidebar__resizer-grip {
+  background: oklch(0.3 0.04 75 / 0.98);
+  border-color: oklch(0.82 0.13 75 / 0.85);
+  box-shadow:
+    0 3px 12px oklch(0 0 0 / 0.45),
+    0 0 0 1px oklch(0.78 0.12 75 / 0.28),
+    inset 0 1px 0 oklch(1 0 0 / 0.1);
+  transform: scale(1.08);
+}
+
+.preview-sidebar__resizer:hover .preview-sidebar__resizer-grip span,
+.preview-sidebar__resizer:focus-visible .preview-sidebar__resizer-grip span,
+body.preview-resizing .preview-sidebar__resizer-grip span {
+  background: oklch(0.82 0.12 75);
+}
+
+.preview-sidebar__resizer:focus-visible {
+  outline: none;
 }
 
 .preview-sidebar__inner {
@@ -813,6 +927,8 @@ html.desktop-app * {
   display: flex;
   flex-direction: column;
   min-width: 0;
+  overflow: hidden;
+  background: oklch(0.13 0 0);
 }
 
 .preview-sidebar__header {

--- a/apps/desktop/src/components/chat/BgToastHost.tsx
+++ b/apps/desktop/src/components/chat/BgToastHost.tsx
@@ -1,0 +1,62 @@
+import { memo, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { useRunStore } from "../../stores/run-store";
+import { useSessionStore } from "../../stores/session-store";
+import { X } from "lucide-react";
+
+function BgToastHostInner() {
+  const { t } = useTranslation();
+  const toasts = useRunStore((s) => s.toasts);
+  const dismissToast = useRunStore((s) => s.dismissToast);
+  const selectSession = useSessionStore((s) => s.selectSession);
+
+  useEffect(() => {
+    const timers: number[] = [];
+    for (const toast of toasts) {
+      if (toast.kind === "waiting") continue;
+      const age = Date.now() - toast.createdAt;
+      const remaining = Math.max(0, 8000 - age);
+      timers.push(
+        window.setTimeout(() => dismissToast(toast.id), remaining),
+      );
+    }
+    return () => timers.forEach((id) => clearTimeout(id));
+  }, [toasts, dismissToast]);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="bg-toast-host" role="region" aria-label={t("run.toastRegion")}>
+      {toasts.map((toast) => {
+        const label =
+          toast.kind === "waiting"
+            ? t("run.toastWaiting", { title: toast.title })
+            : t("run.toastComplete", { title: toast.title });
+        return (
+          <div key={toast.id} className={`bg-toast bg-toast--${toast.kind}`} role="status">
+            <button
+              type="button"
+              className="bg-toast__body"
+              onClick={() => {
+                selectSession(toast.sessionId);
+                dismissToast(toast.id);
+              }}
+            >
+              <span className="bg-toast__text">{label}</span>
+            </button>
+            <button
+              type="button"
+              className="bg-toast__dismiss"
+              aria-label={t("common.close")}
+              onClick={() => dismissToast(toast.id)}
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export const BgToastHost = memo(BgToastHostInner);

--- a/apps/desktop/src/components/chat/ContentRenderer.tsx
+++ b/apps/desktop/src/components/chat/ContentRenderer.tsx
@@ -127,11 +127,14 @@ function ToolBatchBlock({
   const [isOpen, setIsOpen] = useState(false);
   const firstArgs = (children[0] as { args?: unknown } | undefined)?.args;
   const isFileOps = toolName === "file-ops" || toolName === "__file-ops__";
+  const isOfficeOps = toolName === "office-ops";
   const detail = isFileOps
     ? t("activity.tool.fileOps", { count })
-    : formatToolLabel(toolName, firstArgs);
+    : isOfficeOps
+      ? t("activity.tool.officeOps", { count })
+      : formatToolLabel(toolName, firstArgs);
   const label =
-    !isFileOps && count > 1
+    !isFileOps && !isOfficeOps && count > 1
       ? t("activity.tool.batch", { label: detail, count })
       : detail;
 
@@ -283,24 +286,40 @@ function WorkerBlockInner({
   const deliverables = children.filter((c) => c.type === "file-attachment");
   const steps = children.filter((c) => c.type !== "file-attachment");
   const isRunning = status === "running";
-  // Explore/plan flood file ops — keep compact unless user expands
+  // Explore/plan/office flood low-level ops — keep compact unless user expands
   const defaultCollapsed =
-    workerType === "explore" || workerType === "plan" || stepCount >= 8;
+    workerType === "explore" ||
+    workerType === "plan" ||
+    workerType === "office" ||
+    stepCount >= 8;
 
-  const deliverableNodes =
-    deliverables.length > 0
-      ? deliverables.map((child, idx) => (
-          <FileAttachmentBlock
-            key={`${child.path}-${child.name}-${idx}`}
-            name={child.name}
-            size={child.size}
-            mimeType={child.mimeType}
-            path={child.path}
-            servedPath={child.servedPath}
-            src={child.src}
-          />
-        ))
-      : undefined;
+  const progressParts = children.filter((c) => c.type === "office-progress");
+  const latestProgress =
+    progressParts.length > 0
+      ? (progressParts[progressParts.length - 1] as Extract<
+          GroupedContent,
+          { type: "office-progress" }
+        >)
+      : null;
+
+  const deliverableNodes = (
+    <>
+      {latestProgress ? <OfficeProgressBanner part={latestProgress} /> : null}
+      {deliverables.map((child, idx) => (
+        <FileAttachmentBlock
+          key={`${child.path}-${child.name}-${idx}`}
+          name={child.name}
+          size={child.size}
+          mimeType={child.mimeType}
+          path={child.path}
+          servedPath={child.servedPath}
+          src={child.src}
+        />
+      ))}
+    </>
+  );
+
+  const hasDeliverables = !!latestProgress || deliverables.length > 0;
 
   return (
     <ActivityCard
@@ -310,9 +329,10 @@ function WorkerBlockInner({
       stepCount={stepCount}
       badge={scenarioLabel && title !== scenarioLabel ? scenarioLabel : undefined}
       defaultCollapsed={defaultCollapsed}
-      deliverables={deliverableNodes}
+      deliverables={hasDeliverables ? deliverableNodes : undefined}
     >
       {steps.map((child, idx) => {
+        if (child.type === "office-progress") return null;
         if (child.type === "tool-call") {
           return (
             <ToolCallBlock

--- a/apps/desktop/src/components/preview/PreviewSidebar.tsx
+++ b/apps/desktop/src/components/preview/PreviewSidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import {
   FileText,
@@ -32,7 +32,9 @@ function previewTypeMeta(type: Preview["type"] | undefined, t: (key: string) => 
 
 export function PreviewSidebar({ isRunning }: { isRunning?: boolean }) {
   const { t } = useTranslation();
-  const { isOpen, previews, activeId, close, setActive } = usePreviewStore();
+  const { isOpen, previews, activeId, close, setActive, panelWidthPx, setPanelWidthPx } =
+    usePreviewStore();
+  const dragRef = useRef<{ startX: number; startW: number; stageW: number } | null>(null);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -46,6 +48,45 @@ export function PreviewSidebar({ isRunning }: { isRunning?: boolean }) {
     return () => window.removeEventListener("keydown", handler);
   }, [isOpen, close]);
 
+  const onResizePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const stage = e.currentTarget.closest(".chat-stage") as HTMLElement | null;
+      const stageW = stage?.getBoundingClientRect().width ?? window.innerWidth;
+      dragRef.current = {
+        startX: e.clientX,
+        startW: panelWidthPx,
+        stageW,
+      };
+      e.currentTarget.setPointerCapture(e.pointerId);
+      document.body.classList.add("preview-resizing");
+    },
+    [panelWidthPx],
+  );
+
+  const onResizePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      // Drag handle on the left edge: move left → wider panel
+      const next = drag.startW + (drag.startX - e.clientX);
+      setPanelWidthPx(next, drag.stageW);
+    },
+    [setPanelWidthPx],
+  );
+
+  const endResize = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current) return;
+    dragRef.current = null;
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    } catch {
+      /* already released */
+    }
+    document.body.classList.remove("preview-resizing");
+  }, []);
+
   const activePreview = activeId
     ? previews.find((p) => p.id === activeId) ?? null
     : null;
@@ -56,10 +97,41 @@ export function PreviewSidebar({ isRunning }: { isRunning?: boolean }) {
   return (
     <aside
       className={`preview-sidebar ${isOpen ? "preview-sidebar--open" : ""}`}
-      style={{ width: isOpen ? "var(--preview-width)" : 0 }}
+      style={{ width: isOpen ? panelWidthPx : 0 }}
       aria-hidden={!isOpen}
       aria-label={t("preview.documentPreview")}
     >
+      {isOpen && (
+        <div
+          className="preview-sidebar__resizer app-no-drag"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label={t("preview.resize")}
+          aria-valuenow={panelWidthPx}
+          tabIndex={0}
+          onPointerDown={onResizePointerDown}
+          onPointerMove={onResizePointerMove}
+          onPointerUp={endResize}
+          onPointerCancel={endResize}
+          onKeyDown={(e) => {
+            const stage = (e.currentTarget.closest(".chat-stage") as HTMLElement | null)
+              ?.getBoundingClientRect().width;
+            if (e.key === "ArrowLeft") {
+              e.preventDefault();
+              setPanelWidthPx(panelWidthPx + 24, stage);
+            } else if (e.key === "ArrowRight") {
+              e.preventDefault();
+              setPanelWidthPx(panelWidthPx - 24, stage);
+            }
+          }}
+        >
+          <div className="preview-sidebar__resizer-grip" aria-hidden>
+            <span />
+            <span />
+            <span />
+          </div>
+        </div>
+      )}
       <div className="preview-sidebar__inner">
         <header className="preview-sidebar__header">
           <div className="preview-sidebar__title-row">

--- a/apps/desktop/src/components/preview/preview-html.test.ts
+++ b/apps/desktop/src/components/preview/preview-html.test.ts
@@ -3,20 +3,20 @@ import { enhanceOfficePreviewHtml } from "./preview-html";
 import { existsSync, readFileSync } from "node:fs";
 
 describe("enhanceOfficePreviewHtml", () => {
-  it("injects embed class, CSS, patched scale logic, and resize script", () => {
+  it("injects vertical deck scroll + width-fit scale logic", () => {
     const html = "<!DOCTYPE html><html><head></head><body><script>const fill = headless && slides.length === 1;</script></body></html>";
     const out = enhanceOfficePreviewHtml(html);
     expect(out).toContain('class="hive-embed"');
     expect(out).toContain("hive-embed");
     expect(out).toContain('document.documentElement.classList.contains("hive-embed") ? false');
-    expect(out).toContain("maxSlideW");
-    expect(out).toContain("flex-direction: row !important");
-    expect(out).toContain("scroll-snap-type: x mandatory");
+    expect(out).not.toContain("maxSlideW");
+    expect(out).toContain("flex-direction: column !important");
+    expect(out).toContain("overflow-y: auto !important");
+    expect(out).toContain("scroll-snap-type: y proximity");
+    expect(out).toContain("availW / designW");
+    expect(out).toContain("transformOrigin = \"center top\"");
     expect(out).toContain("__hivePreviewHeight");
-    expect(out).toContain("avail.h > 0");
-    expect(out).toContain("transformOrigin = \"center center\"");
     expect(out.indexOf("hive-preview-patch")).toBeLessThan(out.indexOf("</head>"));
-    expect(out.indexOf("hive-preview-patch-js")).toBeGreaterThan(out.indexOf("</body>") === -1 ? 0 : out.lastIndexOf("<script"));
   });
 
   it("patches real officecli HTML when fixture exists", () => {

--- a/apps/desktop/src/components/preview/preview-html.ts
+++ b/apps/desktop/src/components/preview/preview-html.ts
@@ -1,4 +1,4 @@
-/** Patch officecli HTML so slides fit the embed by letterboxing (preserve aspect ratio). */
+/** Patch officecli HTML for vertical deck scroll + width-fit slides (PowerPoint-like). */
 export function enhanceOfficePreviewHtml(html: string): string {
   let out = addHiveEmbedClass(html);
   out = patchOfficeCliScaleLogic(out);
@@ -21,10 +21,10 @@ html.hive-embed body {
 html.hive-embed .sidebar,
 html.hive-embed .sidebar-toggle,
 html.hive-embed .toggle-zone { display: none !important; }
-/* Horizontal filmstrip — slides scroll sideways, not stacked vertically */
+/* Vertical deck — scroll top→bottom like PowerPoint / Keynote */
 html.hive-embed .main {
   display: flex !important;
-  flex-direction: row !important;
+  flex-direction: column !important;
   flex-wrap: nowrap !important;
   flex: 1 1 auto !important;
   width: 100% !important;
@@ -32,30 +32,33 @@ html.hive-embed .main {
   min-width: 0 !important;
   min-height: 0 !important;
   height: 100% !important;
-  padding: 12px 16px !important;
+  padding: 14px 12px 28px !important;
   margin: 0 !important;
-  gap: 14px !important;
+  gap: 18px !important;
   align-items: center !important;
   justify-content: flex-start !important;
   box-sizing: border-box !important;
-  overflow-x: auto !important;
-  overflow-y: hidden !important;
-  scroll-snap-type: x mandatory !important;
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
+  scroll-snap-type: y proximity !important;
   -webkit-overflow-scrolling: touch !important;
 }
 html.hive-embed .slide-container {
   flex: 0 0 auto !important;
-  width: auto !important;
-  max-width: none !important;
-  height: 100% !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  height: auto !important;
+  display: flex !important;
+  flex-direction: column !important;
   align-items: center !important;
-  justify-content: center !important;
+  justify-content: flex-start !important;
   margin: 0 !important;
-  scroll-snap-align: center !important;
+  scroll-snap-align: start !important;
+  box-sizing: border-box !important;
 }
 html.hive-embed .slide-wrapper {
   width: auto !important;
-  max-width: none !important;
+  max-width: 100% !important;
   margin: 0 !important;
   padding: 0 !important;
   display: flex !important;
@@ -64,6 +67,15 @@ html.hive-embed .slide-wrapper {
 }
 html.hive-embed .slide {
   box-shadow: 0 8px 28px rgba(0,0,0,0.35) !important;
+}
+/* Notes sit under each slide in the vertical flow */
+html.hive-embed .notes,
+html.hive-embed .slide-notes,
+html.hive-embed [class*="note"] {
+  width: 100% !important;
+  max-width: 100% !important;
+  box-sizing: border-box !important;
+  margin-top: 0.5rem !important;
 }
 </style>`;
 
@@ -76,27 +88,23 @@ html.hive-embed .slide {
   var rescaleScheduled = false;
   var rescaleRunning = false;
 
-  function getAvail() {
+  function getAvailWidth() {
     var hostW = window.__hivePreviewWidth;
-    var hostH = window.__hivePreviewHeight;
     var main = document.querySelector(".main");
-    var pad = 24;
-    var w = (hostW > 0 ? hostW : (main ? main.clientWidth : window.innerWidth)) - pad;
-    var h = (hostH > 0 ? hostH : (main ? main.clientHeight : window.innerHeight)) - pad;
-    return { w: Math.max(0, w), h: Math.max(0, h) };
+    // Match .main horizontal padding: 12px * 2
+    var padX = 24;
+    var w = (hostW > 0 ? hostW : (main ? main.clientWidth : window.innerWidth)) - padX;
+    return Math.max(0, w);
   }
 
   function hiveFitSlides() {
     if (rescaleRunning) return;
     rescaleRunning = true;
     try {
-      var avail = getAvail();
-      // Width is required; height may be 0 before first host postMessage — fall back to width-only
-      if (avail.w <= 0) return;
+      var availW = getAvailWidth();
+      if (availW <= 0) return;
 
       var slides = document.querySelectorAll(".main > .slide-container .slide");
-      // Leave a peek of the next slide so the strip reads as horizontal, not a single page
-      var maxSlideW = avail.w > 0 ? avail.w * 0.88 : 0;
       slides.forEach(function(slide) {
         slide.style.transform = "none";
         slide.style.margin = "0";
@@ -105,18 +113,15 @@ html.hive-embed .slide {
         var designH = slide.offsetHeight;
         if (designW <= 0 || designH <= 0) return;
 
-        // Fit height first; cap width so neighbors stay visible in the strip
-        var s = avail.h > 0 ? avail.h / designH : avail.w / designW;
-        if (maxSlideW > 0 && designW * s > maxSlideW) {
-          s = maxSlideW / designW;
-        }
+        // Fit-to-width for vertical deck review (height grows with aspect ratio)
+        var s = availW / designW;
         slide.style.transform = "scale(" + s + ")";
-        slide.style.transformOrigin = "center center";
+        slide.style.transformOrigin = "center top";
 
         var wrapper = slide.parentElement;
         if (wrapper) {
           wrapper.style.width = Math.ceil(designW * s) + "px";
-          wrapper.style.maxWidth = "none";
+          wrapper.style.maxWidth = "100%";
           wrapper.style.height = Math.ceil(designH * s) + "px";
           wrapper.style.marginLeft = "0";
           wrapper.style.marginRight = "0";

--- a/apps/desktop/src/i18n/locales/en.json
+++ b/apps/desktop/src/i18n/locales/en.json
@@ -45,7 +45,17 @@
     "collapseSidebar": "Collapse sidebar",
     "sessions": "Sessions",
     "messageCount_one": "1 message",
-    "messageCount_other": "{{count}} messages"
+    "messageCount_other": "{{count}} messages",
+    "stopConfirm": "Stop the background task in “{{title}}”?",
+    "deleteRunningConfirm": "“{{title}}” is still running. Delete will stop it first. Continue?",
+    "running": "Running",
+    "waiting": "Waiting",
+    "stopRun": "Stop task"
+  },
+  "run": {
+    "toastRegion": "Background task notifications",
+    "toastComplete": "“{{title}}” finished",
+    "toastWaiting": "“{{title}}” needs your confirmation"
   },
   "chat": {
     "placeholder": "Ask Hive anything…",

--- a/apps/desktop/src/i18n/locales/en.json
+++ b/apps/desktop/src/i18n/locales/en.json
@@ -110,7 +110,8 @@
       "agentDefault": "Delegate subtask",
       "web": "Fetch web content",
       "batch": "{{label}} · {{count}}×",
-      "fileOps": "File exploration · {{count}} steps"
+      "fileOps": "File exploration · {{count}} steps",
+      "officeOps": "Office ops · {{count}} steps"
     },
     "worker": {
       "office": "Office document",
@@ -172,6 +173,7 @@
     "sheetCount_one": "1 sheet",
     "sheetCount_other": "{{count}} sheets",
     "close": "Close preview (Esc)",
+    "resize": "Drag to resize preview",
     "documentPreview": "Document preview",
     "officeDoc": "Office document",
     "generating": "Generating document, preview coming soon…",

--- a/apps/desktop/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/i18n/locales/zh-CN.json
@@ -45,7 +45,17 @@
     "collapseSidebar": "收起侧栏",
     "sessions": "会话",
     "messageCount_one": "1 条消息",
-    "messageCount_other": "{{count}} 条消息"
+    "messageCount_other": "{{count}} 条消息",
+    "stopConfirm": "停止「{{title}}」的后台任务？",
+    "deleteRunningConfirm": "「{{title}}」仍在执行，删除将先停止任务。确定删除？",
+    "running": "进行中",
+    "waiting": "等待确认",
+    "stopRun": "停止任务"
+  },
+  "run": {
+    "toastRegion": "后台任务通知",
+    "toastComplete": "「{{title}}」已完成",
+    "toastWaiting": "「{{title}}」需要你确认"
   },
   "chat": {
     "placeholder": "向 Hive 提问…",

--- a/apps/desktop/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/i18n/locales/zh-CN.json
@@ -110,7 +110,8 @@
       "agentDefault": "委派子任务",
       "web": "获取网页内容",
       "batch": "{{label}} · {{count}} 次",
-      "fileOps": "文件探索 · {{count}} 步"
+      "fileOps": "文件探索 · {{count}} 步",
+      "officeOps": "Office 操作 · {{count}} 步"
     },
     "worker": {
       "office": "Office 文档",
@@ -172,6 +173,7 @@
     "sheetCount_one": "1 个工作表",
     "sheetCount_other": "{{count}} 个工作表",
     "close": "关闭预览 (Esc)",
+    "resize": "拖动调整预览宽度",
     "documentPreview": "文档预览",
     "officeDoc": "Office 文档",
     "generating": "正在生成文档，预览即将出现…",

--- a/apps/desktop/src/lib/background-session.integration.test.ts
+++ b/apps/desktop/src/lib/background-session.integration.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useRunStore } from "../stores/run-store";
+import { appendContentPart, patchAssistantMessage } from "./chat-message-ops";
+import { finalizeRunContent } from "./finalize-run-content";
+import type { ChatMessage, ContentPart } from "../types/chat";
+
+/**
+ * Simulates ChatPage background mutate path (WS → messageCache by threadId)
+ * without mounting React — switch viewing session must not cancel the run.
+ */
+function applyBackgroundTextDelta(threadId: string, delta: string) {
+  const store = useRunStore.getState();
+  const run = store.getRun(threadId);
+  if (!run) return;
+  store.updateMessageCache(threadId, (prev) =>
+    patchAssistantMessage(prev, run.assistantMsgId, (content) =>
+      appendContentPart(content, { type: "text", text: delta }),
+    ),
+  );
+}
+
+function completeBackgroundRun(threadId: string, opts?: { error?: string; cancelled?: boolean }) {
+  const store = useRunStore.getState();
+  const run = store.getRun(threadId);
+  if (!run) return;
+  const isError = !!opts?.error;
+  store.updateMessageCache(threadId, (prev) =>
+    patchAssistantMessage(prev, run.assistantMsgId, (content) =>
+      finalizeRunContent(content, {
+        cancelled: opts?.cancelled,
+        success: !isError && !opts?.cancelled,
+        error: opts?.error,
+      }),
+    ),
+  );
+  store.beginSettling(threadId);
+  if (!isError && !opts?.cancelled && store.viewingSessionId !== threadId) {
+    store.pushToast({ sessionId: threadId, kind: "complete", title: run.title });
+  }
+}
+
+describe("background session (mock WS path)", () => {
+  beforeEach(() => {
+    useRunStore.setState({
+      runs: {},
+      pendingAsk: {},
+      messageCache: {},
+      toasts: [],
+      viewingSessionId: null,
+    });
+  });
+
+  it("keeps run + updates cache after switching away", () => {
+    const store = useRunStore.getState();
+    const assistantMsgId = "asst-a";
+    const msgs: ChatMessage[] = [
+      { id: "u1", role: "user", content: [{ type: "text", text: "go" }], createdAt: 1 },
+      { id: assistantMsgId, role: "assistant", content: [], createdAt: 2 },
+    ];
+
+    store.beginRun({ sessionId: "A", assistantMsgId, title: "Task A" });
+    store.setMessageCache("A", msgs);
+    store.setViewingSessionId("A");
+    expect(store.hasLiveRun("A")).toBe(true);
+    expect(useRunStore.getState().getInFlightSessionId()).toBe("A");
+
+    // Switch lens to B — no cancel
+    store.setViewingSessionId("B");
+    expect(useRunStore.getState().hasLiveRun("A")).toBe(true);
+    expect(useRunStore.getState().runs["A"]?.phase).toBe("running");
+
+    applyBackgroundTextDelta("A", "hello ");
+    applyBackgroundTextDelta("A", "world");
+
+    const cached = useRunStore.getState().getMessageCache("A")!;
+    const assistant = cached.find((m) => m.id === assistantMsgId)!;
+    const texts = (assistant.content as ContentPart[])
+      .filter((p): p is Extract<ContentPart, { type: "text" }> => p.type === "text")
+      .map((p) => p.text)
+      .join("");
+    expect(texts).toContain("hello");
+    expect(texts).toContain("world");
+
+    // Badge still live; busy blocks another session send
+    expect(useRunStore.getState().getInFlightSessionId()).toBe("A");
+  });
+
+  it("toasts complete when not viewing; no toast on error", () => {
+    const store = useRunStore.getState();
+    store.beginRun({ sessionId: "A", assistantMsgId: "m1", title: "A" });
+    store.setMessageCache("A", [
+      { id: "m1", role: "assistant", content: [{ type: "text", text: "x" }], createdAt: 1 },
+    ]);
+    store.setViewingSessionId("B");
+
+    completeBackgroundRun("A");
+    expect(useRunStore.getState().toasts).toHaveLength(1);
+    expect(useRunStore.getState().toasts[0]!.kind).toBe("complete");
+    expect(useRunStore.getState().hasLiveRun("A")).toBe(false);
+
+    useRunStore.setState({ toasts: [], runs: {} });
+    store.beginRun({ sessionId: "A", assistantMsgId: "m2", title: "A2" });
+    store.setMessageCache("A", [
+      { id: "m2", role: "assistant", content: [{ type: "tool-call", toolCallId: "t1", toolName: "Bash", args: {} }], createdAt: 1 },
+    ]);
+    store.setViewingSessionId("B");
+    completeBackgroundRun("A", { error: "boom" });
+    expect(useRunStore.getState().toasts).toHaveLength(0);
+    expect(useRunStore.getState().hasLiveRun("A")).toBe(false);
+  });
+
+  it("waiting toast when ask-user arrives off-lens", () => {
+    const store = useRunStore.getState();
+    store.beginRun({ sessionId: "A", assistantMsgId: "m1", title: "Need you" });
+    store.setViewingSessionId("B");
+    store.setPendingAsk("A", { askId: "q1", question: "OK?", options: [] });
+    store.setPhase("A", "waiting");
+    store.pushToast({ sessionId: "A", kind: "waiting", title: "Need you" });
+
+    expect(useRunStore.getState().runs["A"]?.phase).toBe("waiting");
+    expect(useRunStore.getState().toasts[0]!.kind).toBe("waiting");
+    expect(useRunStore.getState().getPendingAsk("A")?.askId).toBe("q1");
+  });
+});

--- a/apps/desktop/src/lib/cancel-session-run.ts
+++ b/apps/desktop/src/lib/cancel-session-run.ts
@@ -1,0 +1,50 @@
+import { getChatWsClient } from "./ws-client";
+import { finalizeRunContent } from "./finalize-run-content";
+import { persistAssistantNow } from "./persist-assistant";
+import { patchAssistantMessage } from "./chat-message-ops";
+import { useRunStore } from "../stores/run-store";
+
+/**
+ * Cancel an in-flight session run (sidebar stop / delete-before-cancel).
+ * On RPC failure still locally finalize (M9).
+ */
+export async function cancelSessionRun(sessionId: string): Promise<{ ok: boolean; error?: string }> {
+  const store = useRunStore.getState();
+  const run = store.getRun(sessionId) ?? store.getRunOrSettling(sessionId);
+  if (!run || run.phase === "settling") {
+    return { ok: true };
+  }
+
+  let rpcOk = true;
+  let rpcError: string | undefined;
+  try {
+    await getChatWsClient().request("chat.cancel", { threadId: sessionId });
+  } catch (err) {
+    rpcOk = false;
+    rpcError = err instanceof Error ? err.message : String(err);
+    console.warn("[run] chat.cancel failed", sessionId, rpcError);
+  }
+
+  // Local finalize immediately so UI cannot keep spinning if complete event is late/lost
+  const cached = store.getMessageCache(sessionId);
+  if (cached && run.assistantMsgId) {
+    const next = patchAssistantMessage(cached, run.assistantMsgId, (content) =>
+      finalizeRunContent(content, { cancelled: true }),
+    );
+    store.setMessageCache(sessionId, next);
+    const assistant = next.find((m) => m.id === run.assistantMsgId);
+    if (assistant) persistAssistantNow(assistant.id, assistant.content);
+  }
+
+  store.setPendingAsk(sessionId, null);
+  store.clearToastsForSession(sessionId);
+  store.beginSettling(sessionId);
+  window.setTimeout(() => {
+    const still = useRunStore.getState().runs[sessionId];
+    if (still?.phase === "settling") {
+      useRunStore.getState().clearRun(sessionId);
+    }
+  }, 2_050);
+
+  return { ok: rpcOk, error: rpcError };
+}

--- a/apps/desktop/src/lib/chat-message-ops.ts
+++ b/apps/desktop/src/lib/chat-message-ops.ts
@@ -1,0 +1,56 @@
+import type { ChatMessage, ContentPart } from "../types/chat";
+
+export function patchAssistantMessage(
+  messages: ChatMessage[],
+  assistantMsgId: string | undefined,
+  patch: (content: ContentPart[]) => ContentPart[],
+): ChatMessage[] {
+  if (messages.length === 0) return messages;
+  let idx = assistantMsgId
+    ? messages.findIndex((m) => m.id === assistantMsgId && m.role === "assistant")
+    : -1;
+  if (idx < 0) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]!.role === "assistant") {
+        idx = i;
+        break;
+      }
+    }
+  }
+  if (idx < 0) return messages;
+  const target = messages[idx]!;
+  const nextContent = patch(target.content);
+  if (nextContent === target.content) return messages;
+  const next = messages.slice();
+  next[idx] = { ...target, content: nextContent };
+  return next;
+}
+
+export function appendContentPart(content: ContentPart[], part: ContentPart): ContentPart[] {
+  const updated = content.slice();
+  if (part.type === "text") {
+    const lastPart = updated[updated.length - 1];
+    if (lastPart?.type === "text") {
+      updated[updated.length - 1] = { ...lastPart, text: lastPart.text + part.text };
+    } else {
+      updated.push(part);
+    }
+  } else if (part.type === "reasoning") {
+    const lastPart = updated[updated.length - 1];
+    if (lastPart?.type === "reasoning") {
+      updated[updated.length - 1] = { ...lastPart, text: lastPart.text + part.text };
+    } else {
+      updated.push(part);
+    }
+  } else if (part.type === "office-progress") {
+    const lastPart = updated[updated.length - 1];
+    if (lastPart?.type === "office-progress") {
+      updated[updated.length - 1] = part;
+    } else {
+      updated.push(part);
+    }
+  } else {
+    updated.push(part);
+  }
+  return updated;
+}

--- a/apps/desktop/src/lib/finalize-run-content.test.ts
+++ b/apps/desktop/src/lib/finalize-run-content.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { finalizeRunContent, hasOpenRunParts } from "./finalize-run-content";
+import type { ContentPart } from "../types/chat";
+
+describe("finalizeRunContent", () => {
+  it("closes open tool calls and workers", () => {
+    const content: ContentPart[] = [
+      { type: "tool-call", toolCallId: "t1", toolName: "agent", args: { type: "office" }, startedAt: Date.now() - 1000 },
+      { type: "worker-start", workerId: "w1", workerType: "office", description: "做页" },
+      { type: "office-progress", phase: "adding_slide", slide: 2 },
+    ];
+    const out = finalizeRunContent(content, { success: true });
+    expect(out.find((p) => p.type === "tool-call")).toMatchObject({
+      result: "已结束",
+      isError: false,
+    });
+    expect(out.some((p) => p.type === "worker-complete" && p.workerId === "w1" && p.success)).toBe(true);
+    expect(hasOpenRunParts(out)).toBe(false);
+  });
+
+  it("marks cancelled tools as errors", () => {
+    const content: ContentPart[] = [
+      { type: "tool-call", toolCallId: "t1", toolName: "Bash", args: {} },
+      { type: "worker-start", workerId: "w1", workerType: "general" },
+    ];
+    const out = finalizeRunContent(content, { cancelled: true });
+    expect(out[0]).toMatchObject({ type: "tool-call", result: "已取消", isError: true });
+    expect(out[out.length - 1]).toMatchObject({
+      type: "worker-complete",
+      success: false,
+      error: "已取消",
+    });
+  });
+
+  it("leaves completed parts alone", () => {
+    const content: ContentPart[] = [
+      { type: "tool-call", toolCallId: "t1", toolName: "Read", args: {}, result: "ok", durationMs: 12 },
+      { type: "worker-start", workerId: "w1", workerType: "explore" },
+      { type: "worker-complete", workerId: "w1", workerType: "explore", success: true, duration: 100 },
+    ];
+    const out = finalizeRunContent(content, { success: true });
+    expect(out).toHaveLength(3);
+    expect(out[0]).toMatchObject({ result: "ok", durationMs: 12 });
+    expect(hasOpenRunParts(content)).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/finalize-run-content.ts
+++ b/apps/desktop/src/lib/finalize-run-content.ts
@@ -1,0 +1,85 @@
+import type { ContentPart } from "../types/chat";
+
+export type FinalizeRunOptions = {
+  cancelled?: boolean;
+  success?: boolean;
+  error?: string;
+};
+
+/**
+ * Close out in-flight tool rows / workers so the chat UI cannot keep spinning
+ * after a turn ends (or after we reload a stale persisted snapshot).
+ */
+export function finalizeRunContent(
+  content: ContentPart[],
+  opts: FinalizeRunOptions = {},
+): ContentPart[] {
+  const cancelled = !!opts.cancelled;
+  const failed = opts.success === false || cancelled;
+  const endLabel = cancelled
+    ? "已取消"
+    : failed
+      ? opts.error?.slice(0, 200) || "未完成"
+      : "已结束";
+
+  const startedWorkers = new Map<
+    string,
+    { workerId: string; workerType: string }
+  >();
+  const completedWorkers = new Set<string>();
+
+  const next = content.map((part) => {
+    if (part.type === "worker-start") {
+      startedWorkers.set(part.workerId, {
+        workerId: part.workerId,
+        workerType: part.workerType,
+      });
+      return part;
+    }
+    if (part.type === "worker-complete") {
+      completedWorkers.add(part.workerId);
+      return part;
+    }
+    if (part.type === "tool-call" && part.result === undefined) {
+      const startedAt = part.startedAt;
+      return {
+        ...part,
+        result: endLabel,
+        isError: failed,
+        durationMs:
+          part.durationMs ??
+          (startedAt != null ? Math.max(0, Date.now() - startedAt) : undefined),
+      };
+    }
+    return part;
+  });
+
+  for (const [workerId, meta] of startedWorkers) {
+    if (completedWorkers.has(workerId)) continue;
+    next.push({
+      type: "worker-complete",
+      workerId,
+      workerType: meta.workerType,
+      success: !failed,
+      error: failed ? endLabel : undefined,
+      duration: 0,
+    });
+  }
+
+  return next;
+}
+
+/** True when content still has open tools/workers that would spin in the UI. */
+export function hasOpenRunParts(content: ContentPart[]): boolean {
+  const started = new Set<string>();
+  const completed = new Set<string>();
+  for (const part of content) {
+    if (part.type === "worker-start") started.add(part.workerId);
+    if (part.type === "worker-complete") completed.add(part.workerId);
+    if (part.type === "tool-call" && part.result === undefined) return true;
+  }
+  for (const id of started) {
+    if (!completed.has(id)) return true;
+  }
+  return false;
+}

--- a/apps/desktop/src/lib/group-content-parts.test.ts
+++ b/apps/desktop/src/lib/group-content-parts.test.ts
@@ -44,15 +44,32 @@ describe("groupContentParts", () => {
     expect(grouped[1]).toMatchObject({ type: "text", text: "你好" });
   });
 
-  it("passes through office-progress parts", () => {
+  it("coalesces consecutive office-progress into the latest", () => {
     const parts: ContentPart[] = [
       { type: "office-progress", phase: "routed" },
+      { type: "office-progress", phase: "adding_slide", slide: 1, slideTotal: 8 },
+      { type: "office-progress", phase: "adding_slide", slide: 2, slideTotal: 8 },
+      { type: "office-progress", phase: "adding_slide", slide: 3, slideTotal: 8 },
       { type: "office-progress", phase: "blocked", message: "缺真图" },
     ];
     const grouped = groupContentParts(parts);
-    expect(grouped).toHaveLength(2);
-    expect(grouped[0]).toMatchObject({ type: "office-progress", phase: "routed" });
-    expect(grouped[1]).toMatchObject({ type: "office-progress", phase: "blocked", message: "缺真图" });
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0]).toMatchObject({
+      type: "office-progress",
+      phase: "blocked",
+      message: "缺真图",
+    });
+  });
+
+  it("keeps office-progress when interrupted by other content", () => {
+    const parts: ContentPart[] = [
+      { type: "office-progress", phase: "creating" },
+      { type: "text", text: "中间说明" },
+      { type: "office-progress", phase: "adding_slide", slide: 1 },
+    ];
+    const grouped = groupContentParts(parts);
+    expect(grouped.map((g) => g.type)).toEqual(["office-progress", "text", "office-progress"]);
+    expect(grouped[2]).toMatchObject({ type: "office-progress", phase: "adding_slide", slide: 1 });
   });
 
   it("nests tool calls under active worker", () => {

--- a/apps/desktop/src/lib/group-content-parts.test.ts
+++ b/apps/desktop/src/lib/group-content-parts.test.ts
@@ -130,6 +130,81 @@ describe("groupContentParts", () => {
     expect(grouped.map((g) => g.type)).toEqual(["worker", "office-progress", "worker"]);
   });
 
+  it("folds flat historical officecli rows into one collapsed Office card", () => {
+    const parts: ContentPart[] = [
+      {
+        type: "file-attachment",
+        name: "项目汇报.pptx",
+        size: 1000,
+        mimeType: "application/octet-stream",
+        path: "/tmp/a.pptx",
+      },
+      { type: "office-progress", phase: "creating" },
+      {
+        type: "tool-call",
+        toolCallId: "1",
+        toolName: "officecli",
+        args: { command: "view outline" },
+        result: "ok",
+      },
+      { type: "office-progress", phase: "adding_slide", slide: 1, slideTotal: 3 },
+      {
+        type: "tool-call",
+        toolCallId: "2",
+        toolName: "officecli",
+        args: { command: "add title" },
+        result: "ok",
+      },
+      {
+        type: "tool-call",
+        toolCallId: "3",
+        toolName: "Bash",
+        args: { command: "officecli set text" },
+        result: "ok",
+      },
+      { type: "text", text: "PPT 已完成" },
+    ];
+    const grouped = groupContentParts(parts);
+    expect(grouped.map((g) => g.type)).toEqual(["file-attachment", "worker", "text"]);
+    expect(grouped[1]).toMatchObject({ type: "worker", workerType: "office", status: "completed" });
+    if (grouped[1]?.type === "worker") {
+      expect(grouped[1].children.map((c) => c.type)).toEqual(["office-progress", "tool-batch"]);
+      expect(grouped[1].children[1]).toMatchObject({
+        type: "tool-batch",
+        toolName: "office-ops",
+        count: 3,
+      });
+    }
+  });
+
+  it("nests office-progress into running office worker and batches office tools", () => {
+    const parts: ContentPart[] = [
+      { type: "worker-start", workerId: "w1", workerType: "office", description: "做PPT" },
+      { type: "office-progress", phase: "creating", workerId: "w1" },
+      { type: "tool-call", toolCallId: "1", toolName: "Bash", args: { command: "officecli new" }, workerId: "w1" },
+      { type: "office-progress", phase: "adding_slide", slide: 1, slideTotal: 3, workerId: "w1" },
+      { type: "tool-call", toolCallId: "2", toolName: "Bash", args: { command: "officecli add" }, workerId: "w1" },
+      { type: "tool-call", toolCallId: "3", toolName: "Bash", args: { command: "officecli view" }, workerId: "w1" },
+      { type: "worker-complete", workerId: "w1", workerType: "office", success: true, duration: 1200 },
+    ];
+    const grouped = groupContentParts(parts);
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0]?.type).toBe("worker");
+    if (grouped[0]?.type === "worker") {
+      expect(grouped[0].children.map((c) => c.type)).toEqual(["office-progress", "tool-batch"]);
+      expect(grouped[0].children[0]).toMatchObject({
+        type: "office-progress",
+        phase: "adding_slide",
+        slide: 1,
+      });
+      expect(grouped[0].children[1]).toMatchObject({
+        type: "tool-batch",
+        toolName: "office-ops",
+        count: 3,
+      });
+    }
+  });
+
   it("merges consecutive reasoning blocks inside worker", () => {
     const parts: ContentPart[] = [
       { type: "worker-start", workerId: "w1", workerType: "explore" },

--- a/apps/desktop/src/lib/group-content-parts.ts
+++ b/apps/desktop/src/lib/group-content-parts.ts
@@ -28,14 +28,20 @@ export function groupContentParts(parts: ContentPart[]): GroupedContent[] {
       activeWorkers.set(part.workerId, group);
       result.push(group);
     } else if (part.type === "office-progress") {
-      result.push({
-        type: "office-progress",
+      const next = {
+        type: "office-progress" as const,
         phase: part.phase,
         slide: part.slide,
         slideTotal: part.slideTotal,
         message: part.message,
         workerId: part.workerId,
-      });
+      };
+      const last = result[result.length - 1];
+      if (last?.type === "office-progress") {
+        result[result.length - 1] = next;
+      } else {
+        result.push(next);
+      }
     } else if (part.type === "worker-complete") {
       const group = activeWorkers.get(part.workerId);
       if (group) {

--- a/apps/desktop/src/lib/group-content-parts.ts
+++ b/apps/desktop/src/lib/group-content-parts.ts
@@ -36,11 +36,33 @@ export function groupContentParts(parts: ContentPart[]): GroupedContent[] {
         message: part.message,
         workerId: part.workerId,
       };
-      const last = result[result.length - 1];
-      if (last?.type === "office-progress") {
-        result[result.length - 1] = next;
+      // Prefer nesting into the office worker so the transcript stays one card
+      const nestTarget =
+        (part.workerId ? activeWorkers.get(part.workerId) : undefined) ??
+        [...activeWorkers.values()].find(
+          (w) => w.workerType === "office" && w.status === "running",
+        );
+      if (nestTarget) {
+        const kids = nestTarget.children;
+        let lastProgressIdx = -1;
+        for (let i = kids.length - 1; i >= 0; i--) {
+          if (kids[i]?.type === "office-progress") {
+            lastProgressIdx = i;
+            break;
+          }
+        }
+        if (lastProgressIdx >= 0) {
+          kids[lastProgressIdx] = next;
+        } else {
+          kids.push(next);
+        }
       } else {
-        result.push(next);
+        const last = result[result.length - 1];
+        if (last?.type === "office-progress") {
+          result[result.length - 1] = next;
+        } else {
+          result.push(next);
+        }
       }
     } else if (part.type === "worker-complete") {
       const group = activeWorkers.get(part.workerId);
@@ -72,7 +94,9 @@ export function groupContentParts(parts: ContentPart[]): GroupedContent[] {
   }
 
   return groupWorkerLanes(
-    groupImageGalleries(dedupeTopLevelFileAttachments(mergeToolBatches(mergeReasoning(result)))),
+    compactTopLevelOfficeFlood(
+      groupImageGalleries(dedupeTopLevelFileAttachments(mergeToolBatches(mergeReasoning(result)))),
+    ),
   );
 }
 
@@ -217,17 +241,26 @@ function mergeToolBatches(items: GroupedContent[]): GroupedContent[] {
   const merged: GroupedContent[] = [];
   let batch: GroupedContent[] = [];
   let batchKey: string | null = null;
+  let pendingProgress: GroupedContent | null = null;
+
+  const emitProgress = () => {
+    if (!pendingProgress) return;
+    merged.push(pendingProgress);
+    pendingProgress = null;
+  };
 
   const flushBatch = () => {
     if (batch.length === 0) return;
+    emitProgress();
     if (batch.length === 1) {
-      merged.push(batch[0]);
+      merged.push(batch[0]!);
     } else {
       const first = batch[0] as { type: "tool-call"; toolName: string };
       const key = batchKey ?? first.toolName;
       merged.push({
         type: "tool-batch",
-        toolName: key === "file-ops" ? "file-ops" : first.toolName,
+        toolName:
+          key === "file-ops" ? "file-ops" : key === "office-ops" ? "office-ops" : first.toolName,
         count: batch.length,
         children: batch,
       });
@@ -238,8 +271,8 @@ function mergeToolBatches(items: GroupedContent[]): GroupedContent[] {
 
   for (const item of items) {
     if (item.type === "tool-call") {
-      const tc = item as { type: "tool-call"; toolName: string };
-      const key = toolBatchKey(tc.toolName);
+      const tc = item as { type: "tool-call"; toolName: string; args?: unknown };
+      const key = toolBatchKey(tc.toolName, tc.args);
       if (batch.length > 0 && batchKey === key) {
         batch.push(item);
       } else {
@@ -247,11 +280,15 @@ function mergeToolBatches(items: GroupedContent[]): GroupedContent[] {
         batch.push(item);
         batchKey = key;
       }
+    } else if (item.type === "office-progress") {
+      // Don't shatter officecli rows — keep latest progress for the batch header
+      pendingProgress = item;
     } else if (item.type === "reasoning" && batch.length > 0 && batchKey === "file-ops") {
       // Don't break file-op batches on interleaved model "thinking" inside explore
       continue;
     } else {
       flushBatch();
+      emitProgress();
       if (item.type === "worker") {
         const worker = item as GroupedContent & { type: "worker"; children: GroupedContent[] };
         merged.push({
@@ -264,12 +301,13 @@ function mergeToolBatches(items: GroupedContent[]): GroupedContent[] {
     }
   }
   flushBatch();
+  emitProgress();
 
   return merged;
 }
 
 /** Read/Glob/Grep/File share one batch so explore doesn't emit one row per file. */
-function toolBatchKey(toolName: string): string {
+function toolBatchKey(toolName: string, args?: unknown): string {
   const name = toolName.toLowerCase();
   if (
     name === "read" ||
@@ -281,19 +319,107 @@ function toolBatchKey(toolName: string): string {
   ) {
     return "file-ops";
   }
+  if (name.includes("officecli") || name === "office") return "office-ops";
+  if ((name === "bash" || name === "shell") && isOfficeArgs(args)) return "office-ops";
   return name;
 }
 
+function isOfficeArgs(args: unknown): boolean {
+  try {
+    return /officecli|\.pptx|powerpoint/i.test(JSON.stringify(args ?? ""));
+  } catch {
+    return false;
+  }
+}
+
+function isOfficeToolCall(item: GroupedContent): item is GroupedContent & { type: "tool-call" } {
+  if (item.type !== "tool-call") return false;
+  const name = item.toolName.toLowerCase();
+  if (name.includes("office")) return true;
+  if (name === "bash" || name === "shell") return isOfficeArgs(item.args);
+  return isOfficeArgs(item.args);
+}
+
+function isOfficeNoisePart(item: GroupedContent): boolean {
+  if (item.type === "office-progress") return true;
+  if (item.type === "tool-batch") {
+    return item.toolName === "office-ops" || /officecli/i.test(item.toolName);
+  }
+  return isOfficeToolCall(item);
+}
+
 /**
- * Explore/plan often interleave many different tools — fold the whole process
- * into one collapsed batch when noisy enough.
+ * Historical transcripts often stored officecli steps as flat top-level tool rows
+ * (no workerId). Fold those floods into one collapsed Office card.
+ */
+function compactTopLevelOfficeFlood(items: GroupedContent[]): GroupedContent[] {
+  const out: GroupedContent[] = [];
+  let i = 0;
+  while (i < items.length) {
+    const head = items[i]!;
+    if (!isOfficeNoisePart(head)) {
+      out.push(head);
+      i += 1;
+      continue;
+    }
+
+    let progress: GroupedContent | null = null;
+    const tools: GroupedContent[] = [];
+    let j = i;
+    while (j < items.length && isOfficeNoisePart(items[j]!)) {
+      const it = items[j]!;
+      if (it.type === "office-progress") {
+        progress = it;
+      } else if (it.type === "tool-batch") {
+        tools.push(...it.children);
+      } else if (it.type === "tool-call") {
+        tools.push(it);
+      }
+      j += 1;
+    }
+
+    if (tools.length >= 2 || (tools.length >= 1 && progress)) {
+      const children: GroupedContent[] = [];
+      if (progress) children.push(progress);
+      if (tools.length === 1) {
+        children.push(tools[0]!);
+      } else {
+        children.push({
+          type: "tool-batch",
+          toolName: "office-ops",
+          count: tools.length,
+          children: tools,
+        });
+      }
+      out.push({
+        type: "worker",
+        workerId: `office-compact-${i}`,
+        workerType: "office",
+        children,
+        status: "completed",
+      });
+    } else {
+      for (let k = i; k < j; k++) out.push(items[k]!);
+    }
+    i = j;
+  }
+  return out;
+}
+
+/**
+ * Explore/plan/office flood the transcript with low-level tool rows —
+ * fold into one collapsed batch when noisy enough.
  */
 function compactWorkerProcess(
   children: GroupedContent[],
   workerType: string
 ): GroupedContent[] {
-  const noisy = workerType === "explore" || workerType === "plan";
+  const noisy =
+    workerType === "explore" || workerType === "plan" || workerType === "office";
   if (!noisy) return children;
+
+  const batchName =
+    workerType === "office" ? "office-ops" : "file-ops";
 
   const tools: GroupedContent[] = [];
   const rest: GroupedContent[] = [];
@@ -303,7 +429,7 @@ function compactWorkerProcess(
     } else if (child.type === "tool-batch") {
       tools.push(...child.children);
     } else if (child.type === "reasoning") {
-      // Keep if this worker has no file ops; otherwise hide thinking behind the strip
+      // Keep if this worker has no ops yet; otherwise hide thinking behind the strip
       if (tools.length === 0) rest.push(child);
     } else {
       rest.push(child);
@@ -319,13 +445,18 @@ function compactWorkerProcess(
     return [...tools, ...nonReasoningRest];
   }
 
+  // Keep office-progress banners ahead of the collapsed ops strip
+  const progress = nonReasoningRest.filter((c) => c.type === "office-progress");
+  const otherRest = nonReasoningRest.filter((c) => c.type !== "office-progress");
+
   return [
+    ...progress,
     {
       type: "tool-batch",
-      toolName: "file-ops",
+      toolName: batchName,
       count: tools.length,
       children: tools,
     },
-    ...nonReasoningRest,
+    ...otherRest,
   ];
 }

--- a/apps/desktop/src/lib/persist-assistant.test.ts
+++ b/apps/desktop/src/lib/persist-assistant.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  flushPersistAssistant,
+  persistAssistantNow,
+  schedulePersistAssistant,
+} from "./persist-assistant";
+import type { ContentPart } from "../types/chat";
+
+vi.mock("./db", () => ({
+  updateMessageContent: vi.fn(() => Promise.resolve()),
+}));
+
+import * as db from "./db";
+
+const text = (t: string): ContentPart[] => [{ type: "text", text: t }];
+
+describe("persist-assistant debounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(db.updateMessageContent).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("debounces rapid updates into one write", () => {
+    schedulePersistAssistant("m1", text("a"));
+    schedulePersistAssistant("m1", text("ab"));
+    schedulePersistAssistant("m1", text("abc"));
+    expect(db.updateMessageContent).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1499);
+    expect(db.updateMessageContent).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(db.updateMessageContent).toHaveBeenCalledTimes(1);
+    expect(db.updateMessageContent).toHaveBeenCalledWith("m1", JSON.stringify(text("abc")));
+  });
+
+  it("flush writes immediately and cancels pending timer", () => {
+    schedulePersistAssistant("m1", text("x"));
+    flushPersistAssistant("m1");
+    expect(db.updateMessageContent).toHaveBeenCalledTimes(1);
+    expect(db.updateMessageContent).toHaveBeenCalledWith("m1", JSON.stringify(text("x")));
+
+    vi.advanceTimersByTime(2000);
+    expect(db.updateMessageContent).toHaveBeenCalledTimes(1);
+  });
+
+  it("persistAssistantNow bypasses debounce", () => {
+    schedulePersistAssistant("m1", text("pending"));
+    persistAssistantNow("m1", text("final"));
+    expect(db.updateMessageContent).toHaveBeenCalledTimes(1);
+    expect(db.updateMessageContent).toHaveBeenCalledWith("m1", JSON.stringify(text("final")));
+
+    vi.advanceTimersByTime(2000);
+    expect(db.updateMessageContent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/lib/persist-assistant.ts
+++ b/apps/desktop/src/lib/persist-assistant.ts
@@ -1,0 +1,59 @@
+import * as db from "./db";
+import type { ContentPart } from "../types/chat";
+
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
+const pending = new Map<string, ContentPart[]>();
+
+const DEBOUNCE_MS = 1500;
+
+/** Debounced persist of assistant content (D3.3). */
+export function schedulePersistAssistant(
+  msgId: string | null | undefined,
+  content: ContentPart[],
+): void {
+  if (!msgId) return;
+  pending.set(msgId, content);
+  const prev = timers.get(msgId);
+  if (prev) clearTimeout(prev);
+  timers.set(
+    msgId,
+    setTimeout(() => {
+      timers.delete(msgId);
+      const latest = pending.get(msgId);
+      pending.delete(msgId);
+      if (!latest) return;
+      db.updateMessageContent(msgId, JSON.stringify(latest)).catch((err) => {
+        console.warn("[persist] updateMessageContent failed", msgId, err);
+      });
+    }, DEBOUNCE_MS),
+  );
+}
+
+/** Flush immediately (session switch / complete). */
+export function flushPersistAssistant(msgId: string | null | undefined): void {
+  if (!msgId) return;
+  const prev = timers.get(msgId);
+  if (prev) clearTimeout(prev);
+  timers.delete(msgId);
+  const latest = pending.get(msgId);
+  pending.delete(msgId);
+  if (!latest) return;
+  db.updateMessageContent(msgId, JSON.stringify(latest)).catch((err) => {
+    console.warn("[persist] flush failed", msgId, err);
+  });
+}
+
+/** Immediate persist without debounce (file upsert / heal). */
+export function persistAssistantNow(
+  msgId: string | null | undefined,
+  content: ContentPart[],
+): void {
+  if (!msgId) return;
+  const t = timers.get(msgId);
+  if (t) clearTimeout(t);
+  timers.delete(msgId);
+  pending.delete(msgId);
+  db.updateMessageContent(msgId, JSON.stringify(content)).catch((err) => {
+    console.warn("[persist] immediate failed", msgId, err);
+  });
+}

--- a/apps/desktop/src/pages/ChatPage.tsx
+++ b/apps/desktop/src/pages/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import i18n from "../i18n";
 import { useChatWsClient } from "../hooks/use-chat-ws-client";
@@ -950,9 +950,17 @@ export function ChatPage() {
 
   const isEmpty = messages.length === 0;
   const previewOpen = usePreviewStore((s) => s.isOpen);
+  const previewWidthPx = usePreviewStore((s) => s.panelWidthPx);
 
   return (
-    <div className={`chat-stage chat-shell${previewOpen ? " chat-stage--preview-open" : ""}`}>
+    <div
+      className={`chat-stage chat-shell${previewOpen ? " chat-stage--preview-open" : ""}`}
+      style={
+        previewOpen
+          ? ({ ["--preview-width" as string]: `${previewWidthPx}px` } as CSSProperties)
+          : undefined
+      }
+    >
       <BgToastHost />
       <div ref={scrollRef} className="chat-stage__scroll scrollbar-thin" onScroll={handleScroll}>
         {isEmpty ? (

--- a/apps/desktop/src/pages/ChatPage.tsx
+++ b/apps/desktop/src/pages/ChatPage.tsx
@@ -105,6 +105,36 @@ export function ChatPage() {
 
   const isViewingThread = useCallback((threadId: string) => currentIdRef.current === threadId, []);
 
+  /**
+   * Ensure a live run exists for inbound WS events.
+   * Revives from messageCache after HMR / accidental store loss so background
+   * sessions keep receiving stream updates after a lens switch.
+   */
+  const ensureLiveRun = useCallback((threadId: string): boolean => {
+    const store = useRunStore.getState();
+    if (store.getRun(threadId)) return true;
+    // Do not revive a session that just completed/cancelled
+    if (store.getRunOrSettling(threadId)?.phase === "settling") return false;
+
+    const cached = store.getMessageCache(threadId);
+    const assistant = cached
+      ? [...cached].reverse().find((m) => m.role === "assistant")
+      : undefined;
+    if (!assistant) return false;
+
+    store.beginRun({
+      sessionId: threadId,
+      assistantMsgId: assistant.id,
+      title: truncateActivityLabel(
+        cached?.find((m) => m.role === "user")?.content
+          ?.filter((p): p is Extract<ContentPart, { type: "text" }> => p.type === "text")
+          .map((p) => p.text)
+          .join(" ") || i18n.t("activity.processing"),
+      ),
+    });
+    return !!useRunStore.getState().getRun(threadId);
+  }, []);
+
   /** Apply message updates to the viewed session or a background cache. */
   const mutateThreadMessages = useCallback(
     (threadId: string, updater: (prev: ChatMessage[]) => ChatMessage[]) => {
@@ -131,6 +161,17 @@ export function ChatPage() {
         store.setMessageCache(threadId, next);
         setMessages(next);
         return;
+      }
+      // Seed cache if missing so background WS updates are not silently dropped
+      if (!store.getMessageCache(threadId) && assistantMsgId) {
+        store.setMessageCache(threadId, [
+          {
+            id: assistantMsgId,
+            role: "assistant",
+            content: [],
+            createdAt: Date.now(),
+          },
+        ]);
       }
       store.updateMessageCache(threadId, applyUpdate);
     },
@@ -192,8 +233,11 @@ export function ChatPage() {
           createdAt: r.created_at,
         }));
 
-        // Heal stale spinners from older snapshots when this session is not running.
-        if (!useRunStore.getState().hasLiveRun(currentId)) {
+        // Heal stale spinners only when nothing is in-flight app-wide.
+        // If another lens still has a live run, skip — this session may be that run
+        // after a store blip, and persisting "已中断" would falsely kill the transcript.
+        const runStore = useRunStore.getState();
+        if (!runStore.hasLiveRun(currentId) && !runStore.getInFlightSessionId()) {
           let healed = false;
           msgs = msgs.map((m) => {
             if (m.role !== "assistant" || !hasOpenRunParts(m.content)) return m;
@@ -387,22 +431,26 @@ export function ChatPage() {
   // Stable WS event handlers — useCallback ensures dedup in WsClient Set
   // across React.StrictMode double-mount cycles.
   // Events are accepted for any registered run (including background sessions).
+  const handleAgentStart = useCallback((data: { threadId: string }) => {
+    ensureLiveRun(data.threadId);
+  }, [ensureLiveRun]);
+
   const handleReasoning = useCallback((data: { threadId: string; text: string; seq: number; workerId?: string; workerType?: string }) => {
-    if (!useRunStore.getState().getRun(data.threadId)) return;
+    if (!ensureLiveRun(data.threadId)) return;
     if (data.seq <= lastReasoningSeqRef.current) return;
     lastReasoningSeqRef.current = data.seq;
     if (isViewingThread(data.threadId)) {
       activitySetWorking({ detail: i18n.t("activity.thinking") });
     }
     appendPart(data.threadId, { type: "reasoning", text: data.text, workerId: data.workerId, workerType: data.workerType });
-  }, [appendPart, activitySetWorking, isViewingThread]);
+  }, [appendPart, activitySetWorking, isViewingThread, ensureLiveRun]);
 
   const handleTextDelta = useCallback((data: { threadId: string; text: string; seq: number }) => {
-    if (!useRunStore.getState().getRun(data.threadId)) return;
+    if (!ensureLiveRun(data.threadId)) return;
     if (data.seq !== undefined && data.seq <= lastTextSeqRef.current) return;
     if (data.seq !== undefined) lastTextSeqRef.current = data.seq;
     appendPart(data.threadId, { type: "text", text: data.text });
-  }, [appendPart]);
+  }, [appendPart, ensureLiveRun]);
 
   const handleRoute = useCallback((data: {
     threadId: string;
@@ -412,7 +460,7 @@ export function ChatPage() {
     workerTypes?: string[];
     title?: string;
   }) => {
-    if (!useRunStore.getState().getRun(data.threadId)) return;
+    if (!ensureLiveRun(data.threadId)) return;
 
     const dockTitle =
       data.mode === "inquiry"
@@ -447,25 +495,25 @@ export function ChatPage() {
       workerTypes: data.workerTypes,
       title: data.title,
     });
-  }, [appendPart, activitySetWorking, isViewingThread]);
+  }, [appendPart, activitySetWorking, isViewingThread, ensureLiveRun]);
 
   const handleWorkerStart = useCallback((data: { threadId: string; workerId: string; workerType: string; description?: string; scenarioId?: string }) => {
-    if (!useRunStore.getState().getRun(data.threadId)) return;
+    if (!ensureLiveRun(data.threadId)) return;
     const title = formatWorkerTitle(data.workerType, data.description, data.scenarioId);
     if (isViewingThread(data.threadId)) {
       activitySetWorking({ title, detail: undefined });
     }
     appendPart(data.threadId, { type: "worker-start", workerId: data.workerId, workerType: data.workerType, description: data.description, scenarioId: data.scenarioId });
-  }, [appendPart, activitySetWorking, isViewingThread]);
+  }, [appendPart, activitySetWorking, isViewingThread, ensureLiveRun]);
 
   const handleWorkerComplete = useCallback((data: { threadId: string; workerId: string; workerType: string; success: boolean; error?: string; duration?: number }) => {
-    if (!useRunStore.getState().getRun(data.threadId)) return;
+    if (!ensureLiveRun(data.threadId)) return;
     const title = formatWorkerTitle(data.workerType);
     if (isViewingThread(data.threadId)) {
       activitySetLastCompleted(`${data.success ? "✓" : "✗"} ${title}`);
     }
     appendPart(data.threadId, { type: "worker-complete", workerId: data.workerId, workerType: data.workerType, success: data.success, error: data.error, duration: data.duration });
-  }, [appendPart, activitySetLastCompleted, isViewingThread]);
+  }, [appendPart, activitySetLastCompleted, isViewingThread, ensureLiveRun]);
 
   const handleOfficeProgress = useCallback((data: {
     threadId: string;
@@ -475,7 +523,7 @@ export function ChatPage() {
     message?: string;
     workerId?: string;
   }) => {
-    if (!useRunStore.getState().getRun(data.threadId)) return;
+    if (!ensureLiveRun(data.threadId)) return;
     const detail =
       data.phase === "blocked" && data.message
         ? data.message
@@ -507,10 +555,10 @@ export function ChatPage() {
       message: data.message,
       workerId: data.workerId,
     });
-  }, [appendPart, activitySetWorking, isViewingThread]);
+  }, [appendPart, activitySetWorking, isViewingThread, ensureLiveRun]);
 
   const handleToolCall = useCallback((data: { threadId: string; toolCallId: string; toolName: string; args: unknown; workerId?: string; workerType?: string }) => {
-    if (!useRunStore.getState().getRun(data.threadId)) return;
+    if (!ensureLiveRun(data.threadId)) return;
     if (isViewingThread(data.threadId)) {
       activitySetWorking({ detail: formatToolLabel(data.toolName, data.args) });
     }
@@ -522,15 +570,15 @@ export function ChatPage() {
       workerId: data.workerId,
       startedAt: Date.now(),
     });
-  }, [appendPart, activitySetWorking, isViewingThread]);
+  }, [appendPart, activitySetWorking, isViewingThread, ensureLiveRun]);
 
   const handleToolResult = useCallback((data: { threadId: string; toolCallId: string; toolName: string; result: unknown; isError?: boolean; workerId?: string; workerType?: string }) => {
-    if (!useRunStore.getState().getRun(data.threadId)) return;
+    if (!ensureLiveRun(data.threadId)) return;
     if (isViewingThread(data.threadId)) {
       activitySetLastCompleted(formatToolLabel(data.toolName, undefined));
     }
     updateToolResult(data.threadId, data.toolCallId, data.result, data.isError);
-  }, [updateToolResult, activitySetLastCompleted, isViewingThread]);
+  }, [updateToolResult, activitySetLastCompleted, isViewingThread, ensureLiveRun]);
 
   const handleComplete = useCallback((data: { threadId?: string; cancelled?: boolean; success?: boolean; error?: string }) => {
     const store = useRunStore.getState();
@@ -654,8 +702,8 @@ export function ChatPage() {
 
   // Ask-user handler — keep question in the transcript; restore card when switching back
   const handleAskUser = useCallback((data: { askId: string; threadId: string; question: string; options: Array<{ label: string; description?: string }> }) => {
+    if (!ensureLiveRun(data.threadId)) return;
     const store = useRunStore.getState();
-    if (!store.getRun(data.threadId)) return;
     const pending = { askId: data.askId, question: data.question, options: data.options };
     store.setPendingAsk(data.threadId, pending);
     store.setPhase(data.threadId, "waiting");
@@ -671,11 +719,11 @@ export function ChatPage() {
     }
     activitySetWaiting(truncateActivityLabel(data.question));
     setAskUserData(pending);
-  }, [activitySetWaiting, appendPart, isViewingThread]);
+  }, [activitySetWaiting, appendPart, isViewingThread, ensureLiveRun]);
 
   const handleAskUserTimeout = useCallback((data: { askId: string; threadId: string }) => {
+    if (!ensureLiveRun(data.threadId)) return;
     const store = useRunStore.getState();
-    if (!store.getRun(data.threadId)) return;
     store.setPendingAsk(data.threadId, null);
     store.clearToastsForSession(data.threadId);
     if (store.getRun(data.threadId)?.phase === "waiting") {
@@ -684,11 +732,12 @@ export function ChatPage() {
     if (!isViewingThread(data.threadId)) return;
     setAskUserData((prev) => (prev?.askId === data.askId ? null : prev));
     if (isRunning) activityClearWaiting();
-  }, [isRunning, activityClearWaiting, isViewingThread]);
+  }, [isRunning, activityClearWaiting, isViewingThread, ensureLiveRun]);
 
   // Listen to WS events
   useEffect(() => {
     const unsubs = [
+      onEvent("agent.start", handleAgentStart),
       onEvent("agent.reasoning", handleReasoning),
       onEvent("agent.text-delta", handleTextDelta),
       onEvent("agent.route", handleRoute),
@@ -703,7 +752,7 @@ export function ChatPage() {
       onEvent("agent.ask-user-timeout", handleAskUserTimeout),
     ];
     return () => unsubs.forEach((fn) => fn());
-  }, [onEvent, handleReasoning, handleTextDelta, handleRoute, handleWorkerStart, handleWorkerComplete, handleOfficeProgress, handleToolCall, handleToolResult, handleComplete, handleFile, handleAskUser, handleAskUserTimeout]);
+  }, [onEvent, handleAgentStart, handleReasoning, handleTextDelta, handleRoute, handleWorkerStart, handleWorkerComplete, handleOfficeProgress, handleToolCall, handleToolResult, handleComplete, handleFile, handleAskUser, handleAskUserTimeout]);
 
   const handleCancel = useCallback(async () => {
     const threadId = activeThreadIdRef.current;

--- a/apps/desktop/src/pages/ChatPage.tsx
+++ b/apps/desktop/src/pages/ChatPage.tsx
@@ -18,8 +18,14 @@ import { formatToolLabel } from "../components/chat/activity-labels";
 import { formatWorkerTitle, formatScenarioLabel } from "../components/chat/worker-labels";
 import { useActivityStore } from "../stores/activity-store";
 import * as db from "../lib/db";
+import { finalizeRunContent, hasOpenRunParts } from "../lib/finalize-run-content";
+import { patchAssistantMessage, appendContentPart } from "../lib/chat-message-ops";
+import { schedulePersistAssistant, flushPersistAssistant, persistAssistantNow } from "../lib/persist-assistant";
+import { cancelSessionRun } from "../lib/cancel-session-run";
+import { useRunStore, RUN_SETTLE_MS } from "../stores/run-store";
 import type { ChatMessage, ContentPart } from "../types/chat";
 import { AskUserCard } from "../components/AskUserCard";
+import { BgToastHost } from "../components/chat/BgToastHost";
 import { ArrowUp, Plus, Square } from "lucide-react";
 
 function truncateActivityLabel(text: string, max = 48): string {
@@ -51,7 +57,6 @@ export function ChatPage() {
   const { pendingFiles, uploading, addFiles, removeFile, clearFiles } = useFileUpload();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
-  const [isRunning, setIsRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
 
@@ -68,6 +73,7 @@ export function ChatPage() {
   const stickToBottomRef = useRef(true);
   const wasRunningRef = useRef(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  /** Currently viewed session's in-flight thread (null when viewing a settled session). */
   const activeThreadIdRef = useRef<string | null>(null);
   const lastTextSeqRef = useRef(0);
   const lastReasoningSeqRef = useRef(0);
@@ -85,49 +91,140 @@ export function ChatPage() {
   const createSession = useSessionStore((s) => s.createSession);
   const autoTitle = useSessionStore((s) => s.autoTitle);
   const storeLoading = useSessionStore((s) => s.loading);
-  /** Track the assistant message ID so we can persist it on complete */
-  const assistantMsgIdRef = useRef<string | null>(null);
-  const assistantThreadIdRef = useRef<string | null>(null);
+  /** Derived from run-store so sidebar stop / background complete stay in sync. */
+  const isRunning = useRunStore((s) => {
+    if (!currentId) return false;
+    const run = s.runs[currentId];
+    return !!run && (run.phase === "running" || run.phase === "waiting");
+  });
+  const currentIdRef = useRef<string | null>(null);
+  const prevSessionIdRef = useRef<string | null>(null);
+  const messagesRef = useRef<ChatMessage[]>([]);
+  messagesRef.current = messages;
+  currentIdRef.current = currentId;
 
-  const persistAssistantContent = useCallback((content: ContentPart[]) => {
-    const msgId = assistantMsgIdRef.current;
-    if (!msgId) return;
-    db.updateMessageContent(msgId, JSON.stringify(content)).catch(() => {});
-  }, []);
+  const isViewingThread = useCallback((threadId: string) => currentIdRef.current === threadId, []);
+
+  /** Apply message updates to the viewed session or a background cache. */
+  const mutateThreadMessages = useCallback(
+    (threadId: string, updater: (prev: ChatMessage[]) => ChatMessage[]) => {
+      const store = useRunStore.getState();
+      const run = store.getRun(threadId) ?? store.getRunOrSettling(threadId);
+      const assistantMsgId = run?.assistantMsgId;
+
+      const applyUpdate = (prev: ChatMessage[]) => {
+        const next = updater(prev);
+        if (assistantMsgId) {
+          const prevAssistant = prev.find((m) => m.id === assistantMsgId);
+          const nextAssistant = next.find((m) => m.id === assistantMsgId);
+          if (nextAssistant && (!prevAssistant || nextAssistant.content !== prevAssistant.content)) {
+            schedulePersistAssistant(nextAssistant.id, nextAssistant.content);
+          }
+        }
+        return next;
+      };
+
+      if (isViewingThread(threadId)) {
+        setMessages((prev) => {
+          const next = applyUpdate(prev);
+          store.setMessageCache(threadId, next);
+          return next;
+        });
+        return;
+      }
+      store.updateMessageCache(threadId, applyUpdate);
+    },
+    [isViewingThread],
+  );
 
   // Init store on mount
   useEffect(() => {
     initStore();
   }, [initStore]);
 
-  // When session changes (or first load), load messages and reset ephemeral chat UI
+  // When session changes: cache the outgoing transcript, keep background runs alive
   useEffect(() => {
     if (!currentId) return;
-    setAskUserData(null);
-    setIsRunning(false);
+
+    const store = useRunStore.getState();
+    const prevId = prevSessionIdRef.current;
+    if (prevId && prevId !== currentId) {
+      store.setMessageCache(prevId, messagesRef.current);
+      const prevRun = store.getRun(prevId) ?? store.getRunOrSettling(prevId);
+      if (prevRun) {
+        flushPersistAssistant(prevRun.assistantMsgId);
+      }
+    }
+    prevSessionIdRef.current = currentId;
+    store.setViewingSessionId(currentId);
+
     setError(null);
-    activeThreadIdRef.current = null;
-    assistantMsgIdRef.current = null;
-    assistantThreadIdRef.current = null;
-    useActivityStore.getState().reset();
     usePreviewStore.getState().clear();
+
+    if (store.hasLiveRun(currentId)) {
+      activeThreadIdRef.current = currentId;
+      const run = store.getRun(currentId);
+      activitySetWorking({ title: run?.title ?? i18n.t("activity.processing") });
+      const pendingAsk = store.getPendingAsk(currentId);
+      setAskUserData(pendingAsk ?? null);
+      if (pendingAsk) {
+        activitySetWaiting(truncateActivityLabel(pendingAsk.question));
+      }
+    } else {
+      activeThreadIdRef.current = null;
+      setAskUserData(null);
+      useActivityStore.getState().reset();
+    }
+
+    const cached = store.getMessageCache(currentId);
+    if (cached) {
+      setMessages(cached);
+      return;
+    }
 
     const load = async () => {
       try {
         const rows = await db.listMessages(currentId);
-        const msgs: ChatMessage[] = rows.map((r) => ({
+        let msgs: ChatMessage[] = rows.map((r) => ({
           id: r.id,
           role: r.role as "user" | "assistant",
           content: JSON.parse(r.content) as ContentPart[],
           createdAt: r.created_at,
         }));
-        setMessages(msgs);
+
+        // Heal stale spinners from older snapshots when this session is not running.
+        if (!useRunStore.getState().hasLiveRun(currentId)) {
+          let healed = false;
+          msgs = msgs.map((m) => {
+            if (m.role !== "assistant" || !hasOpenRunParts(m.content)) return m;
+            healed = true;
+            const delivered = m.content.some((p) => p.type === "file-attachment");
+            return {
+              ...m,
+              content: finalizeRunContent(m.content, {
+                success: delivered,
+                error: delivered ? undefined : "已中断",
+              }),
+            };
+          });
+          if (healed) {
+            const lastAssistant = [...msgs].reverse().find((m) => m.role === "assistant");
+            if (lastAssistant) {
+              persistAssistantNow(lastAssistant.id, lastAssistant.content);
+            }
+          }
+        }
+
+        if (currentIdRef.current === currentId) {
+          setMessages(msgs);
+          useRunStore.getState().setMessageCache(currentId, msgs);
+        }
       } catch {
         // DB not available — stay with empty messages
       }
     };
     load();
-  }, [currentId]);
+  }, [currentId, activitySetWorking, activitySetWaiting]);
 
   // Create first session if none exists
   useEffect(() => {
@@ -159,6 +256,23 @@ export function ChatPage() {
     const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
     stickToBottomRef.current = distance < 96;
   }, []);
+
+  // Same-session live→idle (sidebar stop / cancel): sync messages from cache
+  const wasLiveForSessionRef = useRef<{ id: string | null; live: boolean }>({
+    id: null,
+    live: false,
+  });
+  useEffect(() => {
+    const prev = wasLiveForSessionRef.current;
+    if (currentId && prev.id === currentId && prev.live && !isRunning) {
+      const cached = useRunStore.getState().getMessageCache(currentId);
+      if (cached) setMessages(cached);
+      setAskUserData(null);
+      activeThreadIdRef.current = null;
+      activitySetIdle();
+    }
+    wasLiveForSessionRef.current = { id: currentId, live: isRunning };
+  }, [currentId, isRunning, activitySetIdle]);
 
   // Stick to bottom while streaming when user hasn't scrolled up
   useEffect(() => {
@@ -204,111 +318,92 @@ export function ChatPage() {
 
   // Elapsed time for tool calls is per-step (startedAt on each tool-call part).
 
-  // Message mutation helpers (stable references, no deps)
-  const upsertFilePart = useCallback((part: Extract<ContentPart, { type: "file-attachment" }>) => {
-    setMessages((prev) => {
-      if (prev.length === 0) return prev;
-      const last = prev[prev.length - 1];
-      if (last.role !== "assistant") return prev;
-
-      const updated = { ...last, content: [...last.content] };
-      const idx = updated.content.findIndex(
-        (p) =>
-          p.type === "file-attachment" &&
-          (p.path === part.path || p.name === part.name)
-      );
-
-      if (idx >= 0) {
-        updated.content[idx] = part;
-      } else {
-        updated.content.push(part);
-      }
-
-      persistAssistantContent(updated.content);
-      return [...prev.slice(0, -1), updated];
-    });
-  }, [persistAssistantContent]);
-
-  const appendPart = useCallback((part: ContentPart) => {
-    setMessages((prev) => {
-      if (prev.length === 0) return prev;
-      const last = prev[prev.length - 1];
-      if (last.role !== "assistant") return prev;
-
-      const updated = { ...last, content: [...last.content] };
-
-      if (part.type === "text") {
-        const lastPart = updated.content[updated.content.length - 1];
-        if (lastPart?.type === "text") {
-          updated.content[updated.content.length - 1] = { ...lastPart, text: lastPart.text + part.text };
-        } else {
-          updated.content.push(part);
-        }
-      } else if (part.type === "reasoning") {
-        const lastPart = updated.content[updated.content.length - 1];
-        if (lastPart?.type === "reasoning") {
-          updated.content[updated.content.length - 1] = { ...lastPart, text: lastPart.text + part.text };
-        } else {
-          updated.content.push(part);
-        }
-      } else {
-        updated.content.push(part);
-      }
-
-      return [...prev.slice(0, -1), updated];
-    });
-  }, []);
-
-  const updateToolResult = useCallback((toolCallId: string, result: unknown, isError?: boolean) => {
-    const now = Date.now();
-    setMessages((prev) =>
-      prev.map((msg) => {
-        if (msg.role !== "assistant") return msg;
-        return {
-          ...msg,
-          content: msg.content.map((part) => {
-            if (part.type !== "tool-call" || part.toolCallId !== toolCallId) return part;
-            const durationMs = part.startedAt != null ? now - part.startedAt : undefined;
-            return { ...part, result, isError, durationMs };
-          }),
-        };
-      })
+  const upsertFilePart = useCallback((threadId: string, part: Extract<ContentPart, { type: "file-attachment" }>) => {
+    const store = useRunStore.getState();
+    const run = store.getRunOrSettling(threadId);
+    mutateThreadMessages(threadId, (prev) =>
+      patchAssistantMessage(prev, run?.assistantMsgId, (content) => {
+        const updated = content.slice();
+        const idx = updated.findIndex(
+          (p) =>
+            p.type === "file-attachment" &&
+            (p.path === part.path || p.name === part.name),
+        );
+        if (idx >= 0) updated[idx] = part;
+        else updated.push(part);
+        persistAssistantNow(run?.assistantMsgId, updated);
+        return updated;
+      }),
     );
-  }, []);
+  }, [mutateThreadMessages]);
 
-  const failPendingRun = useCallback((message: string) => {
-    setError(message);
-    setIsRunning(false);
-    activeThreadIdRef.current = null;
-    activitySetIdle();
-    setMessages((prev) => {
+  const appendPart = useCallback((threadId: string, part: ContentPart) => {
+    const run = useRunStore.getState().getRun(threadId);
+    mutateThreadMessages(threadId, (prev) =>
+      patchAssistantMessage(prev, run?.assistantMsgId, (content) => appendContentPart(content, part)),
+    );
+  }, [mutateThreadMessages]);
+
+  const updateToolResult = useCallback((threadId: string, toolCallId: string, result: unknown, isError?: boolean) => {
+    const now = Date.now();
+    const run = useRunStore.getState().getRun(threadId);
+    mutateThreadMessages(threadId, (prev) =>
+      patchAssistantMessage(prev, run?.assistantMsgId, (content) =>
+        content.map((part) => {
+          if (part.type !== "tool-call" || part.toolCallId !== toolCallId) return part;
+          const durationMs = part.startedAt != null ? now - part.startedAt : undefined;
+          return { ...part, result, isError, durationMs };
+        }),
+      ),
+    );
+  }, [mutateThreadMessages]);
+
+  const failPendingRun = useCallback((threadId: string, message: string) => {
+    const store = useRunStore.getState();
+    store.clearRun(threadId);
+    store.setPendingAsk(threadId, null);
+
+    const patchEmptyAssistant = (prev: ChatMessage[]): ChatMessage[] => {
       const last = prev[prev.length - 1];
-      if (!last || last.role !== "assistant" || last.content.length > 0) {
-        return prev;
-      }
-
+      if (!last || last.role !== "assistant" || last.content.length > 0) return prev;
       return [
         ...prev.slice(0, -1),
         { ...last, content: [{ type: "text", text: t("chat.processFailed", { detail: message }) }] },
       ];
-    });
-  }, [activitySetIdle, t]);
+    };
+
+    if (isViewingThread(threadId)) {
+      setError(message);
+      activeThreadIdRef.current = null;
+      activitySetIdle();
+      setMessages((prev) => {
+        const next = patchEmptyAssistant(prev);
+        store.setMessageCache(threadId, next);
+        return next;
+      });
+    } else {
+      store.updateMessageCache(threadId, patchEmptyAssistant);
+    }
+  }, [activitySetIdle, isViewingThread, t]);
 
   // Stable WS event handlers — useCallback ensures dedup in WsClient Set
-  // across React.StrictMode double-mount cycles
+  // across React.StrictMode double-mount cycles.
+  // Events are accepted for any registered run (including background sessions).
   const handleReasoning = useCallback((data: { threadId: string; text: string; seq: number; workerId?: string; workerType?: string }) => {
-    if (data.threadId !== activeThreadIdRef.current) return;
+    if (!useRunStore.getState().getRun(data.threadId)) return;
     if (data.seq <= lastReasoningSeqRef.current) return;
     lastReasoningSeqRef.current = data.seq;
-    activitySetWorking({ detail: i18n.t("activity.thinking") });
-    appendPart({ type: "reasoning", text: data.text, workerId: data.workerId, workerType: data.workerType });
-  }, [appendPart, activitySetWorking]);
+    if (isViewingThread(data.threadId)) {
+      activitySetWorking({ detail: i18n.t("activity.thinking") });
+    }
+    appendPart(data.threadId, { type: "reasoning", text: data.text, workerId: data.workerId, workerType: data.workerType });
+  }, [appendPart, activitySetWorking, isViewingThread]);
 
   const handleTextDelta = useCallback((data: { threadId: string; text: string; seq: number }) => {
-    if (data.threadId !== activeThreadIdRef.current) return;
+    if (!useRunStore.getState().getRun(data.threadId)) return;
     if (data.seq !== undefined && data.seq <= lastTextSeqRef.current) return;
     if (data.seq !== undefined) lastTextSeqRef.current = data.seq;
-    appendPart({ type: "text", text: data.text });
+    appendPart(data.threadId, { type: "text", text: data.text });
   }, [appendPart]);
 
   const handleRoute = useCallback((data: {
@@ -319,7 +414,7 @@ export function ChatPage() {
     workerTypes?: string[];
     title?: string;
   }) => {
-    if (data.threadId !== activeThreadIdRef.current) return;
+    if (!useRunStore.getState().getRun(data.threadId)) return;
 
     const dockTitle =
       data.mode === "inquiry"
@@ -343,8 +438,10 @@ export function ChatPage() {
           ? formatWorkerTitle(types[0]!, undefined, data.scenarioId)
           : formatScenarioLabel(data.scenarioId));
 
-    activitySetWorking({ title: dockTitle, detail: detail || undefined });
-    appendPart({
+    if (isViewingThread(data.threadId)) {
+      activitySetWorking({ title: dockTitle, detail: detail || undefined });
+    }
+    appendPart(data.threadId, {
       type: "route",
       mode: data.mode,
       scenarioId: data.scenarioId,
@@ -352,22 +449,25 @@ export function ChatPage() {
       workerTypes: data.workerTypes,
       title: data.title,
     });
-  }, [appendPart, activitySetWorking]);
+  }, [appendPart, activitySetWorking, isViewingThread]);
 
   const handleWorkerStart = useCallback((data: { threadId: string; workerId: string; workerType: string; description?: string; scenarioId?: string }) => {
-    if (data.threadId !== activeThreadIdRef.current) return;
+    if (!useRunStore.getState().getRun(data.threadId)) return;
     const title = formatWorkerTitle(data.workerType, data.description, data.scenarioId);
-    activitySetWorking({ title, detail: undefined });
-    appendPart({ type: "worker-start", workerId: data.workerId, workerType: data.workerType, description: data.description, scenarioId: data.scenarioId });
-    // Preview sidebar is user-initiated only (Codex-style) — do not auto-open on worker start
-  }, [appendPart, activitySetWorking]);
+    if (isViewingThread(data.threadId)) {
+      activitySetWorking({ title, detail: undefined });
+    }
+    appendPart(data.threadId, { type: "worker-start", workerId: data.workerId, workerType: data.workerType, description: data.description, scenarioId: data.scenarioId });
+  }, [appendPart, activitySetWorking, isViewingThread]);
 
   const handleWorkerComplete = useCallback((data: { threadId: string; workerId: string; workerType: string; success: boolean; error?: string; duration?: number }) => {
-    if (data.threadId !== activeThreadIdRef.current) return;
+    if (!useRunStore.getState().getRun(data.threadId)) return;
     const title = formatWorkerTitle(data.workerType);
-    activitySetLastCompleted(`${data.success ? "✓" : "✗"} ${title}`);
-    appendPart({ type: "worker-complete", workerId: data.workerId, workerType: data.workerType, success: data.success, error: data.error, duration: data.duration });
-  }, [appendPart, activitySetLastCompleted]);
+    if (isViewingThread(data.threadId)) {
+      activitySetLastCompleted(`${data.success ? "✓" : "✗"} ${title}`);
+    }
+    appendPart(data.threadId, { type: "worker-complete", workerId: data.workerId, workerType: data.workerType, success: data.success, error: data.error, duration: data.duration });
+  }, [appendPart, activitySetLastCompleted, isViewingThread]);
 
   const handleOfficeProgress = useCallback((data: {
     threadId: string;
@@ -377,29 +477,31 @@ export function ChatPage() {
     message?: string;
     workerId?: string;
   }) => {
-    if (data.threadId !== activeThreadIdRef.current) return;
+    if (!useRunStore.getState().getRun(data.threadId)) return;
     const detail =
       data.phase === "blocked" && data.message
         ? data.message
         : data.phase === "adding_slide" && data.slide != null
           ? (data.slideTotal != null ? `第 ${data.slide}/${data.slideTotal} 页` : `第 ${data.slide} 页`)
           : undefined;
-    activitySetWorking({
-      title:
-        data.phase === "routed"
-          ? "已交给 Office"
-          : data.phase === "creating"
-            ? "正在建稿"
-            : data.phase === "validating"
-              ? "检查版式"
-              : data.phase === "delivering"
-                ? "正在交付"
-                : data.phase === "blocked"
-                  ? "需要修正"
-                  : "Office 进行中",
-      detail,
-    });
-    appendPart({
+    if (isViewingThread(data.threadId)) {
+      activitySetWorking({
+        title:
+          data.phase === "routed"
+            ? "已交给 Office"
+            : data.phase === "creating"
+              ? "正在建稿"
+              : data.phase === "validating"
+                ? "检查版式"
+                : data.phase === "delivering"
+                  ? "正在交付"
+                  : data.phase === "blocked"
+                    ? "需要修正"
+                    : "Office 进行中",
+        detail,
+      });
+    }
+    appendPart(data.threadId, {
       type: "office-progress",
       phase: data.phase,
       slide: data.slide,
@@ -407,12 +509,14 @@ export function ChatPage() {
       message: data.message,
       workerId: data.workerId,
     });
-  }, [appendPart, activitySetWorking]);
+  }, [appendPart, activitySetWorking, isViewingThread]);
 
   const handleToolCall = useCallback((data: { threadId: string; toolCallId: string; toolName: string; args: unknown; workerId?: string; workerType?: string }) => {
-    if (data.threadId !== activeThreadIdRef.current) return;
-    activitySetWorking({ detail: formatToolLabel(data.toolName, data.args) });
-    appendPart({
+    if (!useRunStore.getState().getRun(data.threadId)) return;
+    if (isViewingThread(data.threadId)) {
+      activitySetWorking({ detail: formatToolLabel(data.toolName, data.args) });
+    }
+    appendPart(data.threadId, {
       type: "tool-call",
       toolCallId: data.toolCallId,
       toolName: data.toolName,
@@ -420,62 +524,77 @@ export function ChatPage() {
       workerId: data.workerId,
       startedAt: Date.now(),
     });
-  }, [appendPart, activitySetWorking]);
+  }, [appendPart, activitySetWorking, isViewingThread]);
 
   const handleToolResult = useCallback((data: { threadId: string; toolCallId: string; toolName: string; result: unknown; isError?: boolean; workerId?: string; workerType?: string }) => {
-    if (data.threadId !== activeThreadIdRef.current) return;
-    activitySetLastCompleted(formatToolLabel(data.toolName, undefined));
-    updateToolResult(data.toolCallId, data.result, data.isError);
-  }, [updateToolResult, activitySetLastCompleted]);
+    if (!useRunStore.getState().getRun(data.threadId)) return;
+    if (isViewingThread(data.threadId)) {
+      activitySetLastCompleted(formatToolLabel(data.toolName, undefined));
+    }
+    updateToolResult(data.threadId, data.toolCallId, data.result, data.isError);
+  }, [updateToolResult, activitySetLastCompleted, isViewingThread]);
 
   const handleComplete = useCallback((data: { threadId?: string; cancelled?: boolean; success?: boolean; error?: string }) => {
-    const tid = activeThreadIdRef.current ?? assistantThreadIdRef.current;
-    if (data.threadId && tid && data.threadId !== tid) return;
-    setIsRunning(false);
-    setAskUserData(null);
-    activeThreadIdRef.current = null;
-    activitySetIdle();
-    if (data.cancelled) {
-      appendPart({ type: "text", text: t("chat.executionCancelled") });
-    } else if (data.success === false && data.error) {
-      setError(data.error);
-      appendPart({ type: "text", text: t("chat.processFailed", { detail: data.error }) });
-    }
-    // Ensure the assistant message is never left empty after completion
-    setMessages((prev) => {
-      const lastMsg = prev[prev.length - 1];
-      if (lastMsg?.role === "assistant" && lastMsg.content.length === 0) {
-        const fallbackText = data.success === false && data.error
-          ? t("chat.processFailed", { detail: data.error })
-          : (data as { text?: string }).text ?? t("chat.taskNoOutput");
-        return [
-          ...prev.slice(0, -1),
-          {
-            ...lastMsg,
-            content: [{ type: "text", text: fallbackText }],
-          },
-        ];
-      }
-      return prev;
-    });
-    // Persist after stream settles (late file events may still arrive)
-    if (tid && !data.cancelled) {
-      window.setTimeout(() => {
-        setMessages((prev) => {
-          const lastMsg = prev[prev.length - 1];
-          if (lastMsg?.role === "assistant") {
-            persistAssistantContent(lastMsg.content);
-          }
-          return prev;
+    const store = useRunStore.getState();
+    const tid = data.threadId ?? activeThreadIdRef.current ?? undefined;
+    if (!tid || !store.getRun(tid)) return;
+
+    const run = store.getRun(tid)!;
+    store.beginSettling(tid);
+    store.setPendingAsk(tid, null);
+
+    const viewing = isViewingThread(tid);
+    const isError = data.success === false && !!data.error;
+
+    mutateThreadMessages(tid, (prev) =>
+      patchAssistantMessage(prev, run.assistantMsgId, (content) => {
+        let c = content;
+        if (data.cancelled) {
+          c = appendContentPart(c, { type: "text", text: t("chat.executionCancelled") });
+        } else if (isError) {
+          c = appendContentPart(c, { type: "text", text: t("chat.processFailed", { detail: data.error }) });
+        }
+        c = finalizeRunContent(c, {
+          cancelled: data.cancelled,
+          success: data.success,
+          error: data.error,
         });
-      }, 400);
+        if (c.length === 0) {
+          const fallbackText = isError
+            ? t("chat.processFailed", { detail: data.error })
+            : (data as { text?: string }).text ?? t("chat.taskNoOutput");
+          c = [{ type: "text", text: fallbackText }];
+        }
+        return c;
+      }),
+    );
+
+    if (!viewing && !isError && !data.cancelled) {
+      store.pushToast({
+        sessionId: tid,
+        kind: "complete",
+        title: run.title,
+      });
     }
-  }, [appendPart, activitySetIdle, persistAssistantContent, t]);
+
+    if (viewing) {
+      setAskUserData(null);
+      activeThreadIdRef.current = null;
+      activitySetIdle();
+      if (isError) setError(data.error!);
+    }
+
+    flushPersistAssistant(run.assistantMsgId);
+
+    window.setTimeout(() => {
+      store.clearRun(tid);
+    }, RUN_SETTLE_MS + 50);
+  }, [activitySetIdle, isViewingThread, mutateThreadMessages, t]);
 
   const handleFile = useCallback((data: { threadId: string; name: string; path: string; servedPath?: string; size: number; mimeType: string; type: string; src?: string }) => {
-    const threadId = activeThreadIdRef.current ?? assistantThreadIdRef.current;
-    if (!threadId || data.threadId !== threadId) return;
-    upsertFilePart({
+    const run = useRunStore.getState().getRunOrSettling(data.threadId);
+    if (!run) return;
+    upsertFilePart(data.threadId, {
       type: "file-attachment",
       name: data.name,
       size: data.size,
@@ -484,6 +603,8 @@ export function ChatPage() {
       servedPath: data.servedPath,
       src: data.src,
     });
+
+    if (!isViewingThread(data.threadId)) return;
 
     const previewType = isPreviewableFile(data.name);
     if (!previewType) return;
@@ -531,21 +652,41 @@ export function ChatPage() {
         })
         .catch(() => {});
     }
-  }, [upsertFilePart]);
+  }, [upsertFilePart, isViewingThread]);
 
-  // Ask-user handler — keep question in the transcript
+  // Ask-user handler — keep question in the transcript; restore card when switching back
   const handleAskUser = useCallback((data: { askId: string; threadId: string; question: string; options: Array<{ label: string; description?: string }> }) => {
-    if (data.threadId !== activeThreadIdRef.current) return;
+    const store = useRunStore.getState();
+    if (!store.getRun(data.threadId)) return;
+    const pending = { askId: data.askId, question: data.question, options: data.options };
+    store.setPendingAsk(data.threadId, pending);
+    store.setPhase(data.threadId, "waiting");
+    appendPart(data.threadId, { type: "text", text: data.question });
+    if (!isViewingThread(data.threadId)) {
+      const run = store.getRun(data.threadId);
+      store.pushToast({
+        sessionId: data.threadId,
+        kind: "waiting",
+        title: run?.title ?? truncateActivityLabel(data.question),
+      });
+      return;
+    }
     activitySetWaiting(truncateActivityLabel(data.question));
-    setAskUserData({ askId: data.askId, question: data.question, options: data.options });
-    appendPart({ type: "text", text: data.question });
-  }, [activitySetWaiting, appendPart]);
+    setAskUserData(pending);
+  }, [activitySetWaiting, appendPart, isViewingThread]);
 
   const handleAskUserTimeout = useCallback((data: { askId: string; threadId: string }) => {
-    if (data.threadId !== activeThreadIdRef.current) return;
+    const store = useRunStore.getState();
+    if (!store.getRun(data.threadId)) return;
+    store.setPendingAsk(data.threadId, null);
+    store.clearToastsForSession(data.threadId);
+    if (store.getRun(data.threadId)?.phase === "waiting") {
+      store.setPhase(data.threadId, "running");
+    }
+    if (!isViewingThread(data.threadId)) return;
     setAskUserData((prev) => (prev?.askId === data.askId ? null : prev));
     if (isRunning) activityClearWaiting();
-  }, [isRunning, activityClearWaiting]);
+  }, [isRunning, activityClearWaiting, isViewingThread]);
 
   // Listen to WS events
   useEffect(() => {
@@ -569,12 +710,15 @@ export function ChatPage() {
   const handleCancel = useCallback(async () => {
     const threadId = activeThreadIdRef.current;
     if (!threadId) return;
-    try {
-      await request("chat.cancel", { threadId });
-    } catch {
-      // Ignore cancel errors — agent.complete event will reset state
+    await cancelSessionRun(threadId);
+    if (isViewingThread(threadId)) {
+      setAskUserData(null);
+      activeThreadIdRef.current = null;
+      activitySetIdle();
+      const cached = useRunStore.getState().getMessageCache(threadId);
+      if (cached) setMessages(cached);
     }
-  }, [request]);
+  }, [activitySetIdle, isViewingThread]);
 
   // Submit ask-user answer — leave it in the transcript as a user turn
   const handleAskUserSubmit = useCallback(async (answer: string) => {
@@ -586,6 +730,7 @@ export function ChatPage() {
       // Ignore — server may have timed out
     }
     setAskUserData(null);
+    if (currentId) useRunStore.getState().setPendingAsk(currentId, null);
     if (isRunning) activityClearWaiting();
 
     const sessionId = currentId;
@@ -606,6 +751,7 @@ export function ChatPage() {
     const skip = t("askUser.skipAnswer");
     request("chat.answerAskUser", { askId: askUserData.askId, answer: skip }).catch(() => {});
     setAskUserData(null);
+    if (currentId) useRunStore.getState().setPendingAsk(currentId, null);
     if (isRunning) activityClearWaiting();
     const userMsg: ChatMessage = {
       id: crypto.randomUUID(),
@@ -625,17 +771,28 @@ export function ChatPage() {
     stickToBottomRef.current = true;
 
     setError(null);
+    let threadId = currentId;
 
     try {
       await getChatWsClient().waitForConnected();
 
       // Use current session as threadId, or create one
-      let sessionId = currentId;
-      if (!sessionId) {
-        sessionId = await createSession();
+      if (!threadId) {
+        threadId = await createSession();
       }
-      const threadId = sessionId;
-      activeThreadIdRef.current = threadId;
+      if (!threadId) {
+        throw new Error(t("chat.sendFailed", { detail: "no session" }));
+      }
+      const activeThreadId = threadId;
+
+      // Agent is single-dispatch today — don't start another session while one runs.
+      const inFlight = useRunStore.getState().getInFlightSessionId();
+      if (inFlight && inFlight !== activeThreadId) {
+        setError(t("chat.turnBusyHint"));
+        return;
+      }
+
+      activeThreadIdRef.current = activeThreadId;
       lastTextSeqRef.current = 0;
       lastReasoningSeqRef.current = 0;
 
@@ -666,24 +823,28 @@ export function ChatPage() {
         createdAt: now,
       };
 
-      assistantMsgIdRef.current = assistantMsgId;
-      assistantThreadIdRef.current = threadId;
+      const titleSrc = text || pendingFiles.map((f) => f.name).slice(0, 3).join(", ");
+      useRunStore.getState().beginRun({
+        sessionId: activeThreadId,
+        assistantMsgId,
+        title: titleSrc || i18n.t("activity.processing"),
+      });
 
-      setMessages((prev) => [...prev, userMsg, assistantMsg]);
+      setMessages((prev) => {
+        const next = [...prev, userMsg, assistantMsg];
+        useRunStore.getState().setMessageCache(activeThreadId, next);
+        return next;
+      });
       setInput("");
       clearFiles();
-      setIsRunning(true);
       activityBeginRun();
 
       // Persist user + empty assistant placeholder (updated as stream progresses)
-      db.insertMessage(userMsgId, threadId, "user", JSON.stringify(userContent), now).catch(() => {});
-      db.insertMessage(assistantMsgId, threadId, "assistant", "[]", now).catch(() => {});
+      db.insertMessage(userMsgId, activeThreadId, "user", JSON.stringify(userContent), now).catch(() => {});
+      db.insertMessage(assistantMsgId, activeThreadId, "assistant", "[]", now).catch(() => {});
 
       // Auto-title from first user message
-      if (threadId) {
-        const titleSrc = text || pendingFiles.map(f => f.name).slice(0, 3).join(', ');
-        if (titleSrc) autoTitle(threadId, titleSrc);
-      }
+      if (titleSrc) autoTitle(activeThreadId, titleSrc);
 
       if (inputRef.current) {
         inputRef.current.style.height = `${COMPOSER_INPUT_LINE_PX}px`;
@@ -691,16 +852,17 @@ export function ChatPage() {
       }
 
       const attachments = pendingFiles.map(f => ({ type: f.type, path: f.path, name: f.name, size: f.size, mimeType: f.mimeType }));
-      await request("chat.send", { prompt: text || undefined, threadId, attachments: attachments.length > 0 ? attachments : undefined });
+      await request("chat.send", { prompt: text || undefined, threadId: activeThreadId, attachments: attachments.length > 0 ? attachments : undefined });
     } catch (err) {
       const errorMessage = err instanceof Error
         ? err.message
         : typeof err === "string"
           ? err
           : t("chat.sendFailed", { detail: JSON.stringify(err) });
-      failPendingRun(errorMessage);
+      if (threadId) failPendingRun(threadId, errorMessage);
+      else setError(errorMessage);
     }
-  }, [input, pendingFiles, isRunning, request, clearFiles, currentId, createSession, autoTitle, failPendingRun, activityBeginRun]);
+  }, [input, pendingFiles, isRunning, request, clearFiles, currentId, createSession, autoTitle, failPendingRun, activityBeginRun, t]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -746,6 +908,7 @@ export function ChatPage() {
 
   return (
     <div className={`chat-stage chat-shell${previewOpen ? " chat-stage--preview-open" : ""}`}>
+      <BgToastHost />
       <div ref={scrollRef} className="chat-stage__scroll scrollbar-thin" onScroll={handleScroll}>
         {isEmpty ? (
           <EmptyState />

--- a/apps/desktop/src/pages/ChatPage.tsx
+++ b/apps/desktop/src/pages/ChatPage.tsx
@@ -125,11 +125,11 @@ export function ChatPage() {
       };
 
       if (isViewingThread(threadId)) {
-        setMessages((prev) => {
-          const next = applyUpdate(prev);
-          store.setMessageCache(threadId, next);
-          return next;
-        });
+        // Compute outside setState so Zustand cache writes never run during React render
+        // (calling setMessageCache inside setMessages updater re-renders ChatPage mid-render).
+        const next = applyUpdate(messagesRef.current);
+        store.setMessageCache(threadId, next);
+        setMessages(next);
         return;
       }
       store.updateMessageCache(threadId, applyUpdate);
@@ -376,11 +376,9 @@ export function ChatPage() {
       setError(message);
       activeThreadIdRef.current = null;
       activitySetIdle();
-      setMessages((prev) => {
-        const next = patchEmptyAssistant(prev);
-        store.setMessageCache(threadId, next);
-        return next;
-      });
+      const next = patchEmptyAssistant(messagesRef.current);
+      store.setMessageCache(threadId, next);
+      setMessages(next);
     } else {
       store.updateMessageCache(threadId, patchEmptyAssistant);
     }
@@ -830,11 +828,9 @@ export function ChatPage() {
         title: titleSrc || i18n.t("activity.processing"),
       });
 
-      setMessages((prev) => {
-        const next = [...prev, userMsg, assistantMsg];
-        useRunStore.getState().setMessageCache(activeThreadId, next);
-        return next;
-      });
+      const next = [...messagesRef.current, userMsg, assistantMsg];
+      useRunStore.getState().setMessageCache(activeThreadId, next);
+      setMessages(next);
       setInput("");
       clearFiles();
       activityBeginRun();

--- a/apps/desktop/src/pages/Dashboard.tsx
+++ b/apps/desktop/src/pages/Dashboard.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useLogPolling } from "../hooks/use-log-polling";
 import { useSessionStore } from "../stores/session-store";
+import { useRunStore } from "../stores/run-store";
+import { cancelSessionRun } from "../lib/cancel-session-run";
 import { ConfigPage } from "./ConfigPage";
 import { PluginPage } from "./PluginPage";
 import { SkillPage } from "./SkillPage";
@@ -22,6 +24,7 @@ import {
   Puzzle,
   Sparkles,
   Clapperboard,
+  Square,
 } from "lucide-react";
 import type { Session } from "../types/chat";
 import { formatRelativeTime } from "../lib/session-utils";
@@ -134,6 +137,14 @@ export function Dashboard() {
                 }}
                 onDelete={async (e) => {
                   e.stopPropagation();
+                  const live = useRunStore.getState().hasLiveRun(session.id);
+                  if (live) {
+                    const ok = window.confirm(
+                      t("session.deleteRunningConfirm", { title: session.title }),
+                    );
+                    if (!ok) return;
+                    await cancelSessionRun(session.id);
+                  }
                   await deleteSession(session.id);
                   setEditingId(null);
                 }}
@@ -206,9 +217,23 @@ function SessionItem({
   onDelete,
 }: SessionItemProps) {
   const { t } = useTranslation();
+  const runPhase = useRunStore((s) => {
+    const run = s.runs[session.id];
+    if (!run) return null;
+    if (run.phase === "running" || run.phase === "waiting") return run.phase;
+    return null;
+  });
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter") onRenameConfirm();
     if (e.key === "Escape") onRenameCancel();
+  };
+
+  const handleStop = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const ok = window.confirm(t("session.stopConfirm", { title: session.title }));
+    if (!ok) return;
+    await cancelSessionRun(session.id);
   };
 
   return (
@@ -220,7 +245,15 @@ function SessionItem({
           : "hover:bg-stone-800/50 text-stone-400"
       }`}
     >
-      <MessageSquare className="w-3.5 h-3.5 shrink-0 opacity-50" />
+      {runPhase ? (
+        <span
+          className={`session-run-dot session-run-dot--${runPhase}`}
+          title={runPhase === "waiting" ? t("session.waiting") : t("session.running")}
+          aria-label={runPhase === "waiting" ? t("session.waiting") : t("session.running")}
+        />
+      ) : (
+        <MessageSquare className="w-3.5 h-3.5 shrink-0 opacity-50" />
+      )}
       <div className="flex-1 min-w-0">
         {isEditing ? (
           <input
@@ -238,15 +271,28 @@ function SessionItem({
           </p>
         )}
         <p className="text-[10px] text-stone-600 mt-0.5">
-          {session.messageCount > 0
-            ? t("session.messageCount", { count: session.messageCount })
-            : t("common.empty")}
+          {runPhase === "waiting"
+            ? t("session.waiting")
+            : runPhase === "running"
+              ? t("session.running")
+              : session.messageCount > 0
+                ? t("session.messageCount", { count: session.messageCount })
+                : t("common.empty")}
           <span className="mx-1">·</span>
           {formatRelativeTime(session.updatedAt)}
         </p>
       </div>
       {!isEditing && (
         <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+          {runPhase && (
+            <button
+              onClick={handleStop}
+              className="p-0.5 rounded text-stone-600 hover:text-amber-400 hover:bg-stone-700"
+              title={t("session.stopRun")}
+            >
+              <Square className="w-3 h-3" />
+            </button>
+          )}
           <button
             onClick={(e) => { e.stopPropagation(); onRenameStart(); }}
             className="p-0.5 rounded text-stone-600 hover:text-stone-300 hover:bg-stone-700"

--- a/apps/desktop/src/stores/preview-store.test.ts
+++ b/apps/desktop/src/stores/preview-store.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clampPreviewWidth,
+  PREVIEW_WIDTH_DEFAULT,
+  PREVIEW_WIDTH_MIN,
+  usePreviewStore,
+} from "./preview-store";
+
+const memory = new Map<string, string>();
+vi.stubGlobal("localStorage", {
+  getItem: (k: string) => memory.get(k) ?? null,
+  setItem: (k: string, v: string) => {
+    memory.set(k, v);
+  },
+  removeItem: (k: string) => {
+    memory.delete(k);
+  },
+  clear: () => memory.clear(),
+});
+
+describe("clampPreviewWidth", () => {
+  it("clamps to min/max by stage", () => {
+    expect(clampPreviewWidth(100, 1000)).toBe(PREVIEW_WIDTH_MIN);
+    expect(clampPreviewWidth(900, 1000)).toBe(720);
+    expect(clampPreviewWidth(500, 1000)).toBe(500);
+  });
+});
+
+describe("usePreviewStore panel width", () => {
+  beforeEach(() => {
+    memory.clear();
+    // Clear persisted width so default bump is not masked by old localStorage
+    usePreviewStore.setState({ panelWidthPx: PREVIEW_WIDTH_DEFAULT });
+  });
+
+  it("persists resized width", () => {
+    usePreviewStore.getState().setPanelWidthPx(700, 1200);
+    expect(usePreviewStore.getState().panelWidthPx).toBe(700);
+    expect(memory.get("hive.previewPanelWidth")).toBe("700");
+  });
+});

--- a/apps/desktop/src/stores/preview-store.ts
+++ b/apps/desktop/src/stores/preview-store.ts
@@ -11,10 +11,45 @@ export interface Preview {
   sourceMessageId: string;
 }
 
+const WIDTH_STORAGE_KEY = "hive.previewPanelWidth";
+/** Previous shipped defaults — treat as "never customized" so we can widen. */
+const LEGACY_DEFAULTS = new Set([640, 768]);
+/** Default ~52rem — PPT needs readable width; user can drag. */
+export const PREVIEW_WIDTH_DEFAULT = 832;
+export const PREVIEW_WIDTH_MIN = 360;
+export const PREVIEW_WIDTH_MAX_RATIO = 0.72;
+
+function readStoredWidth(): number {
+  try {
+    const raw = localStorage.getItem(WIDTH_STORAGE_KEY);
+    if (!raw) return PREVIEW_WIDTH_DEFAULT;
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return PREVIEW_WIDTH_DEFAULT;
+    // Users who never dragged still have the old factory default
+    if (LEGACY_DEFAULTS.has(n)) return PREVIEW_WIDTH_DEFAULT;
+    return clampPreviewWidth(n);
+  } catch {
+    return PREVIEW_WIDTH_DEFAULT;
+  }
+}
+
+export function clampPreviewWidth(px: number, stageWidth?: number): number {
+  const maxByStage =
+    stageWidth && stageWidth > 0
+      ? Math.floor(stageWidth * PREVIEW_WIDTH_MAX_RATIO)
+      : typeof window !== "undefined"
+        ? Math.floor(window.innerWidth * PREVIEW_WIDTH_MAX_RATIO)
+        : 960;
+  const max = Math.max(PREVIEW_WIDTH_MIN, maxByStage);
+  return Math.round(Math.min(max, Math.max(PREVIEW_WIDTH_MIN, px)));
+}
+
 interface PreviewState {
   previews: Preview[];
   activeId: string | null;
   isOpen: boolean;
+  /** Sidebar width in CSS pixels (user-resizable). */
+  panelWidthPx: number;
 
   addPreview: (p: Preview) => void;
   setActive: (id: string | null) => void;
@@ -24,12 +59,14 @@ interface PreviewState {
   openFor: (preview: Preview) => void;
   close: () => void;
   clear: () => void;
+  setPanelWidthPx: (px: number, stageWidth?: number) => void;
 }
 
 export const usePreviewStore = create<PreviewState>((set) => ({
   previews: [],
   activeId: null,
   isOpen: false,
+  panelWidthPx: typeof window !== "undefined" ? readStoredWidth() : PREVIEW_WIDTH_DEFAULT,
 
   addPreview: (p) =>
     set((state) => {
@@ -73,4 +110,14 @@ export const usePreviewStore = create<PreviewState>((set) => ({
   close: () => set({ isOpen: false }),
 
   clear: () => set({ previews: [], activeId: null, isOpen: false }),
+
+  setPanelWidthPx: (px, stageWidth) => {
+    const next = clampPreviewWidth(px, stageWidth);
+    try {
+      localStorage.setItem(WIDTH_STORAGE_KEY, String(next));
+    } catch {
+      /* ignore quota / private mode */
+    }
+    set({ panelWidthPx: next });
+  },
 }));

--- a/apps/desktop/src/stores/run-store.test.ts
+++ b/apps/desktop/src/stores/run-store.test.ts
@@ -41,6 +41,28 @@ describe("useRunStore", () => {
     expect(useRunStore.getState().getRunOrSettling("a")?.assistantMsgId).toBe("m1");
   });
 
+  // Regression: ISSUE-001 — Found by /qa on 2026-07-17
+  // Report: .gstack/qa-reports/qa-report-hive-desktop-2026-07-17.md
+  it("expired settling does not clearRun synchronously during getRunOrSettling", async () => {
+    const s = useRunStore.getState();
+    s.beginRun({ sessionId: "a", assistantMsgId: "m1", title: "t" });
+    useRunStore.setState((state) => ({
+      runs: {
+        ...state.runs,
+        a: {
+          ...state.runs.a!,
+          phase: "settling",
+          settleUntil: Date.now() - 1,
+        },
+      },
+    }));
+    expect(useRunStore.getState().getRunOrSettling("a")).toBeUndefined();
+    // Still present until microtask flush (safe for React render)
+    expect(useRunStore.getState().runs.a).toBeDefined();
+    await Promise.resolve();
+    expect(useRunStore.getState().runs.a).toBeUndefined();
+  });
+
   it("dedupes toasts by session+kind", () => {
     const s = useRunStore.getState();
     s.pushToast({ sessionId: "a", kind: "complete", title: "A" });

--- a/apps/desktop/src/stores/run-store.test.ts
+++ b/apps/desktop/src/stores/run-store.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useRunStore } from "./run-store";
+
+describe("useRunStore", () => {
+  beforeEach(() => {
+    useRunStore.setState({
+      runs: {},
+      pendingAsk: {},
+      messageCache: {},
+      toasts: [],
+      viewingSessionId: null,
+    });
+  });
+
+  it("tracks a single in-flight run", () => {
+    const store = useRunStore.getState();
+    store.beginRun({
+      sessionId: "a",
+      assistantMsgId: "m1",
+      title: "做 PPT",
+    });
+    expect(store.getInFlightSessionId()).toBe("a");
+    expect(useRunStore.getState().hasLiveRun("a")).toBe(true);
+    expect(useRunStore.getState().getRun("a")?.phase).toBe("running");
+  });
+
+  it("moves to waiting then back to running", () => {
+    const s = useRunStore.getState();
+    s.beginRun({ sessionId: "a", assistantMsgId: "m1", title: "t" });
+    s.setPhase("a", "waiting");
+    expect(useRunStore.getState().getRun("a")?.phase).toBe("waiting");
+    s.setPhase("a", "running");
+    expect(useRunStore.getState().getRun("a")?.phase).toBe("running");
+  });
+
+  it("settling hides getRun but getRunOrSettling still works", () => {
+    const s = useRunStore.getState();
+    s.beginRun({ sessionId: "a", assistantMsgId: "m1", title: "t" });
+    s.beginSettling("a");
+    expect(useRunStore.getState().getRun("a")).toBeUndefined();
+    expect(useRunStore.getState().getRunOrSettling("a")?.assistantMsgId).toBe("m1");
+  });
+
+  it("dedupes toasts by session+kind", () => {
+    const s = useRunStore.getState();
+    s.pushToast({ sessionId: "a", kind: "complete", title: "A" });
+    s.pushToast({ sessionId: "a", kind: "complete", title: "A2" });
+    expect(useRunStore.getState().toasts).toHaveLength(1);
+    expect(useRunStore.getState().toasts[0]!.title).toBe("A2");
+  });
+
+  it("updates message cache for background sessions", () => {
+    const s = useRunStore.getState();
+    s.setMessageCache("a", [
+      { id: "u1", role: "user", content: [{ type: "text", text: "hi" }], createdAt: 1 },
+    ]);
+    s.updateMessageCache("a", (prev) => [
+      ...prev,
+      { id: "a1", role: "assistant", content: [{ type: "text", text: "ok" }], createdAt: 2 },
+    ]);
+    expect(useRunStore.getState().getMessageCache("a")).toHaveLength(2);
+  });
+});

--- a/apps/desktop/src/stores/run-store.ts
+++ b/apps/desktop/src/stores/run-store.ts
@@ -141,7 +141,18 @@ export const useRunStore = create<RunState>((set, get) => ({
     if (!run) return undefined;
     if (run.phase === "settling") {
       if (run.settleUntil != null && Date.now() > run.settleUntil) {
-        get().clearRun(sessionId);
+        // Never clearRun synchronously here — callers may run during React render
+        // (and Zustand setState mid-render throws / corrupts subscribers).
+        queueMicrotask(() => {
+          const still = get().runs[sessionId];
+          if (
+            still?.phase === "settling" &&
+            still.settleUntil != null &&
+            Date.now() > still.settleUntil
+          ) {
+            get().clearRun(sessionId);
+          }
+        });
         return undefined;
       }
     }

--- a/apps/desktop/src/stores/run-store.ts
+++ b/apps/desktop/src/stores/run-store.ts
@@ -1,0 +1,220 @@
+import { create } from "zustand";
+import type { ChatMessage } from "../types/chat";
+
+export type RunPhase = "running" | "waiting" | "settling";
+
+export type SessionRun = {
+  sessionId: string;
+  assistantMsgId: string;
+  phase: RunPhase;
+  title: string;
+  startedAt: number;
+  lastError?: string;
+  /** settling until timestamp (ms) */
+  settleUntil?: number;
+};
+
+export type PendingAsk = {
+  askId: string;
+  question: string;
+  options: Array<{ label: string; description?: string }>;
+};
+
+export type BgToastKind = "complete" | "waiting";
+
+export type BgToast = {
+  id: string;
+  sessionId: string;
+  kind: BgToastKind;
+  title: string;
+  createdAt: number;
+};
+
+/** Keep accepting late agent.file briefly after agent.complete. */
+export const RUN_SETTLE_MS = 2_000;
+
+type RunState = {
+  runs: Record<string, SessionRun>;
+  pendingAsk: Record<string, PendingAsk>;
+  messageCache: Record<string, ChatMessage[]>;
+  toasts: BgToast[];
+  viewingSessionId: string | null;
+
+  setViewingSessionId: (id: string | null) => void;
+
+  beginRun: (opts: {
+    sessionId: string;
+    assistantMsgId: string;
+    title: string;
+  }) => void;
+  setPhase: (sessionId: string, phase: RunPhase, extra?: Partial<SessionRun>) => void;
+  beginSettling: (sessionId: string) => void;
+  clearRun: (sessionId: string) => void;
+
+  getRun: (sessionId: string) => SessionRun | undefined;
+  getRunOrSettling: (sessionId: string) => SessionRun | undefined;
+  hasLiveRun: (sessionId: string) => boolean;
+  getInFlightSessionId: () => string | null;
+
+  setPendingAsk: (sessionId: string, ask: PendingAsk | null) => void;
+  getPendingAsk: (sessionId: string) => PendingAsk | undefined;
+
+  setMessageCache: (sessionId: string, messages: ChatMessage[]) => void;
+  getMessageCache: (sessionId: string) => ChatMessage[] | undefined;
+  updateMessageCache: (
+    sessionId: string,
+    updater: (prev: ChatMessage[]) => ChatMessage[],
+  ) => ChatMessage[] | undefined;
+
+  pushToast: (toast: Omit<BgToast, "id" | "createdAt">) => void;
+  dismissToast: (id: string) => void;
+  clearToastsForSession: (sessionId: string) => void;
+};
+
+export const useRunStore = create<RunState>((set, get) => ({
+  runs: {},
+  pendingAsk: {},
+  messageCache: {},
+  toasts: [],
+  viewingSessionId: null,
+
+  setViewingSessionId: (id) => set({ viewingSessionId: id }),
+
+  beginRun: ({ sessionId, assistantMsgId, title }) =>
+    set((state) => ({
+      runs: {
+        ...state.runs,
+        [sessionId]: {
+          sessionId,
+          assistantMsgId,
+          phase: "running",
+          title,
+          startedAt: Date.now(),
+        },
+      },
+    })),
+
+  setPhase: (sessionId, phase, extra) =>
+    set((state) => {
+      const prev = state.runs[sessionId];
+      if (!prev) return state;
+      return {
+        runs: {
+          ...state.runs,
+          [sessionId]: { ...prev, ...extra, phase },
+        },
+      };
+    }),
+
+  beginSettling: (sessionId) =>
+    set((state) => {
+      const prev = state.runs[sessionId];
+      if (!prev) return state;
+      return {
+        runs: {
+          ...state.runs,
+          [sessionId]: {
+            ...prev,
+            phase: "settling",
+            settleUntil: Date.now() + RUN_SETTLE_MS,
+          },
+        },
+      };
+    }),
+
+  clearRun: (sessionId) =>
+    set((state) => {
+      const { [sessionId]: _, ...rest } = state.runs;
+      const { [sessionId]: __, ...askRest } = state.pendingAsk;
+      return { runs: rest, pendingAsk: askRest };
+    }),
+
+  getRun: (sessionId) => {
+    const run = get().runs[sessionId];
+    if (!run) return undefined;
+    if (run.phase === "settling") return undefined;
+    return run;
+  },
+
+  getRunOrSettling: (sessionId) => {
+    const run = get().runs[sessionId];
+    if (!run) return undefined;
+    if (run.phase === "settling") {
+      if (run.settleUntil != null && Date.now() > run.settleUntil) {
+        get().clearRun(sessionId);
+        return undefined;
+      }
+    }
+    return run;
+  },
+
+  hasLiveRun: (sessionId) => {
+    const run = get().runs[sessionId];
+    return !!run && (run.phase === "running" || run.phase === "waiting");
+  },
+
+  getInFlightSessionId: () => {
+    const runs = get().runs;
+    for (const id of Object.keys(runs)) {
+      const r = runs[id]!;
+      if (r.phase === "running" || r.phase === "waiting") return id;
+    }
+    return null;
+  },
+
+  setPendingAsk: (sessionId, ask) =>
+    set((state) => {
+      if (!ask) {
+        const { [sessionId]: _, ...rest } = state.pendingAsk;
+        return { pendingAsk: rest };
+      }
+      return { pendingAsk: { ...state.pendingAsk, [sessionId]: ask } };
+    }),
+
+  getPendingAsk: (sessionId) => get().pendingAsk[sessionId],
+
+  setMessageCache: (sessionId, messages) =>
+    set((state) => ({
+      messageCache: { ...state.messageCache, [sessionId]: messages },
+    })),
+
+  getMessageCache: (sessionId) => get().messageCache[sessionId],
+
+  updateMessageCache: (sessionId, updater) => {
+    const prev = get().messageCache[sessionId];
+    if (!prev) return undefined;
+    const next = updater(prev);
+    set((state) => ({
+      messageCache: { ...state.messageCache, [sessionId]: next },
+    }));
+    return next;
+  },
+
+  pushToast: (toast) =>
+    set((state) => {
+      const dedupeKey = `${toast.sessionId}:${toast.kind}`;
+      const filtered = state.toasts.filter(
+        (t) => `${t.sessionId}:${t.kind}` !== dedupeKey,
+      );
+      return {
+        toasts: [
+          ...filtered,
+          {
+            ...toast,
+            id: crypto.randomUUID(),
+            createdAt: Date.now(),
+          },
+        ],
+      };
+    }),
+
+  dismissToast: (id) =>
+    set((state) => ({
+      toasts: state.toasts.filter((t) => t.id !== id),
+    })),
+
+  clearToastsForSession: (sessionId) =>
+    set((state) => ({
+      toasts: state.toasts.filter((t) => t.sessionId !== sessionId),
+    })),
+}));

--- a/apps/server/src/graceful-shutdown.ts
+++ b/apps/server/src/graceful-shutdown.ts
@@ -51,7 +51,23 @@ export function registerGracefulShutdown(options: GracefulShutdownOptions): () =
     shutdown('uncaughtException', 1)
   }
   function handleUnhandledRejection(reason: unknown) {
-    console.error('[shutdown] Unhandled rejection:', reason)
+    // AI SDK / AbortController sometimes reject with `{}` — log something useful
+    let detail: string
+    if (reason instanceof Error) {
+      detail = reason.stack || reason.message
+    } else if (reason && typeof reason === 'object') {
+      try {
+        detail = JSON.stringify(reason)
+      } catch {
+        detail = Object.prototype.toString.call(reason)
+      }
+      if (detail === '{}') {
+        detail = 'empty object (often a drained streamText rejection after provider error)'
+      }
+    } else {
+      detail = String(reason)
+    }
+    console.error('[shutdown] Unhandled rejection:', detail)
     // Log only — don't crash the process
   }
 

--- a/packages/core/src/agents/runtime/LLMRuntime.ts
+++ b/packages/core/src/agents/runtime/LLMRuntime.ts
@@ -57,20 +57,41 @@ export const AGENT_PRESETS: Record<string, AgentPreset> = {
 // LLM Runtime
 // ============================================
 
+const GENERIC_NO_OUTPUT =
+  /^No output generated\.?(?: Check the stream for errors\.)?$/i;
+
 /**
  * Extract the real provider error from AI SDK wrapper errors.
  *
- * Vercel AI SDK wraps provider errors as AI_APICallError with a generic
- * "No output generated" message. The actual error lives in:
+ * Vercel AI SDK often wraps failures as AI_NoOutputGeneratedError /
+ * AI_APICallError with a generic "No output generated" message. The real
+ * error may live in:
+ *   - error.cause
  *   - error.data?.error?.message  (parsed)
  *   - error.responseBody           (raw JSON string)
  *   - error.statusCode             (HTTP status)
  *
  * Falls back to the original error message if no structured data is found.
  */
-function extractProviderErrorMessage(error: unknown): string {
+export function extractProviderErrorMessage(error: unknown): string {
+  if (error == null) return 'Unknown stream error';
+
+  // Abort / SDK sometimes rejects with `{}` — useless if stringified as [object Object]
+  if (typeof error === 'object' && !(error instanceof Error)) {
+    const keys = Object.keys(error as object);
+    if (keys.length === 0) return 'Stream aborted or failed with empty error';
+  }
+
   if (error && typeof error === 'object') {
     const e = error as Record<string, unknown>;
+
+    // Prefer nested cause (NoOutputGeneratedError / APICallError wrap the real failure)
+    if (e.cause != null && e.cause !== error) {
+      const fromCause = extractProviderErrorMessage(e.cause);
+      if (fromCause && !GENERIC_NO_OUTPUT.test(fromCause)) {
+        return fromCause;
+      }
+    }
 
     // AI SDK v6: AI_APICallError.data.error.message
     const data = e.data as Record<string, unknown> | undefined;
@@ -78,6 +99,12 @@ function extractProviderErrorMessage(error: unknown): string {
     if (typeof dataError?.message === 'string') {
       const status = typeof e.statusCode === 'number' ? `[${e.statusCode}] ` : '';
       return `${status}${dataError.message}`;
+    }
+
+    // OpenAI-compat: data.message / data.msg
+    if (typeof data?.message === 'string') {
+      const status = typeof e.statusCode === 'number' ? `[${e.statusCode}] ` : '';
+      return `${status}${data.message}`;
     }
 
     // Fallback: raw responseBody JSON string
@@ -89,10 +116,42 @@ function extractProviderErrorMessage(error: unknown): string {
           const status = typeof e.statusCode === 'number' ? `[${e.statusCode}] ` : '';
           return `${status}${bodyError.message}`;
         }
+        if (typeof body?.message === 'string') {
+          return body.message;
+        }
       } catch { /* not JSON, use raw message */ }
+      // Non-JSON body still useful (rate-limit HTML, plain text)
+      if (e.responseBody.length > 0 && e.responseBody.length < 500) {
+        return e.responseBody;
+      }
     }
   }
-  return error instanceof Error ? error.message : String(error);
+
+  if (error instanceof Error) {
+    return error.message || error.name;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+/** Swallow rejections from streamText accessors after a stream failure. */
+function drainStreamResult(streamResult: {
+  text: PromiseLike<unknown>;
+  finishReason: PromiseLike<unknown>;
+  steps: PromiseLike<unknown>;
+  usage: PromiseLike<unknown>;
+  totalUsage: PromiseLike<unknown>;
+}): void {
+  void Promise.all([
+    Promise.resolve(streamResult.text),
+    Promise.resolve(streamResult.finishReason),
+    Promise.resolve(streamResult.steps),
+    Promise.resolve(streamResult.usage),
+    Promise.resolve(streamResult.totalUsage),
+  ]).then(undefined, () => {});
 }
 
 /**
@@ -233,6 +292,7 @@ export class LLMRuntime {
 
         const normalizedConfig = self.normalizeConfig(config, spec);
 
+        let streamError: unknown;
         const streamResult = streamText({
           model,
           prompt: normalizedConfig.prompt,
@@ -241,6 +301,9 @@ export class LLMRuntime {
           tools: normalizedConfig.tools,
           stopWhen: stepCountIs(normalizedConfig.maxSteps ?? 10),
           abortSignal: normalizedConfig.abortSignal,
+          onError: ({ error }) => {
+            streamError = error;
+          },
         });
 
         try {
@@ -273,56 +336,79 @@ export class LLMRuntime {
                   },
                 };
                 break;
+
+              case 'error': {
+                // AI SDK yields error parts then often ends with 0 steps →
+                // generic NoOutputGeneratedError. Surface the real error now.
+                const realMessage = extractProviderErrorMessage(chunk.error ?? streamError);
+                resolveResult(self.buildErrorResult(startTime, realMessage, modelSpec));
+                drainStreamResult(streamResult);
+                return;
+              }
             }
           }
         } catch (error) {
           const err = error instanceof Error ? error : new Error(String(error));
           if (err.name === 'AbortError') {
             resolveResult(self.buildErrorResult(startTime, 'Request aborted', modelSpec));
+            drainStreamResult(streamResult);
             return;
           }
-          // Extract real provider error from AI SDK wrapper (vs generic "No output generated")
-          const realMessage = extractProviderErrorMessage(error);
+          const realMessage = extractProviderErrorMessage(streamError ?? error);
           resolveResult(self.buildErrorResult(startTime, realMessage, modelSpec));
+          drainStreamResult(streamResult);
+          return;
+        }
 
-          // Drain streamResult promises to prevent unhandled rejections.
-          // When the stream fails, streamText() internals may still have pending
-          // promises that reject — catching them prevents noisy unhandledRejection.
-          void Promise.all([
-            Promise.resolve(streamResult.text),
-            Promise.resolve(streamResult.finishReason),
-            Promise.resolve(streamResult.steps),
-            Promise.resolve(streamResult.usage),
-            Promise.resolve(streamResult.totalUsage),
-          ]).then(undefined, () => {});
+        // Stream closed with 0 finish-steps (provider drop / abort) — prefer onError
+        if (streamError != null) {
+          resolveResult(
+            self.buildErrorResult(
+              startTime,
+              extractProviderErrorMessage(streamError),
+              modelSpec,
+            ),
+          );
+          drainStreamResult(streamResult);
           return;
         }
 
         // 等待完整结果
-        const [text, finishReason, steps, totalUsage] = await Promise.all([
-          streamResult.text,
-          streamResult.finishReason,
-          streamResult.steps,
-          streamResult.totalUsage,
-        ]);
+        try {
+          const [text, finishReason, steps, totalUsage] = await Promise.all([
+            streamResult.text,
+            streamResult.finishReason,
+            streamResult.steps,
+            streamResult.totalUsage,
+          ]);
 
-        const toolsUsed = self.collectToolsFromSteps(steps);
+          const toolsUsed = self.collectToolsFromSteps(steps);
 
-        resolveResult({
-          text,
-          tools: toolsUsed,
-          usage: totalUsage
-            ? {
-                promptTokens: totalUsage.inputTokens ?? 0,
-                completionTokens: totalUsage.outputTokens ?? 0,
-              }
-            : undefined,
-          steps: steps.map(step => self.mapStepResult(step)),
-          success: finishReason !== 'error',
-          error: finishReason === 'error' ? 'Generation finished with error' : undefined,
-          duration: Date.now() - startTime,
-          modelSpec,
-        });
+          resolveResult({
+            text,
+            tools: toolsUsed,
+            usage: totalUsage
+              ? {
+                  promptTokens: totalUsage.inputTokens ?? 0,
+                  completionTokens: totalUsage.outputTokens ?? 0,
+                }
+              : undefined,
+            steps: steps.map(step => self.mapStepResult(step)),
+            success: finishReason !== 'error',
+            error: finishReason === 'error' ? 'Generation finished with error' : undefined,
+            duration: Date.now() - startTime,
+            modelSpec,
+          });
+        } catch (error) {
+          resolveResult(
+            self.buildErrorResult(
+              startTime,
+              extractProviderErrorMessage(streamError ?? error),
+              modelSpec,
+            ),
+          );
+          drainStreamResult(streamResult);
+        }
       } finally {
         // 消费者 break for-await 循环后，async generator 被 GC
         // 但 resultPromise 可能永远 pending，这里确保它被 reject

--- a/packages/core/tests/unit/extract-provider-error.test.ts
+++ b/packages/core/tests/unit/extract-provider-error.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { extractProviderErrorMessage } from "../../src/agents/runtime/LLMRuntime.js";
+
+describe("extractProviderErrorMessage", () => {
+  it("unwraps AI SDK data.error.message", () => {
+    const err = Object.assign(new Error("No output generated. Check the stream for errors."), {
+      data: { error: { message: "Insufficient balance" } },
+      statusCode: 402,
+    });
+    expect(extractProviderErrorMessage(err)).toBe("[402] Insufficient balance");
+  });
+
+  it("prefers cause over generic No output generated", () => {
+    const cause = Object.assign(new Error("No output generated. Check the stream for errors."), {
+      cause: Object.assign(new Error("wrapped"), {
+        data: { error: { message: "model not found" } },
+        statusCode: 404,
+      }),
+    });
+    expect(extractProviderErrorMessage(cause)).toBe("[404] model not found");
+  });
+
+  it("handles empty object abort reasons", () => {
+    expect(extractProviderErrorMessage({})).toMatch(/empty error/i);
+  });
+
+  it("parses responseBody JSON", () => {
+    const err = Object.assign(new Error("No output generated."), {
+      responseBody: JSON.stringify({ error: { message: "rate limited" } }),
+      statusCode: 429,
+    });
+    expect(extractProviderErrorMessage(err)).toBe("[429] rate limited");
+  });
+});


### PR DESCRIPTION
## Summary
- Desktop lens-style background sessions: switching chats no longer cancels the in-flight turn; sidebar Running/Waiting badges, mutex busy hint, complete/waiting toasts, Stop confirm
- Office preview: vertical fit-to-width deck scroll, wider default rail with a visible drag-resize handle (persisted)
- Quieter Office process UI: collapse officecli floods (including historical flat rows) into one Office card
- Core: surface real provider stream errors instead of generic “No output generated”

## Test plan
- [x] Unit: run-store / background-session / group-content-parts / preview-html / preview-store
- [x] Manual QA: switch session keeps Running badge; mutex hint; Stop confirm; vertical preview + resize
- [ ] Smoke after merge: new PPT turn collapses tools; reopen preview after hard refresh

Closes #150

Made with [Cursor](https://cursor.com)